### PR TITLE
set tarLongFileMode as posix in maven-assembly-plugin configuration

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -88,6 +88,7 @@
               <descriptors>
                 <descriptor>scripts/assembly-docs.xml</descriptor>
               </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
posix mode allows userid without size limitation