### PR TITLE
Fix for #30, rename jar suffix to -bootable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A WildFly bootable jar contains both the server and your packaged application (a
 Once the application has been built and packaged as a bootable jar, you can start the application using the following command:
 
 ```
-java -jar target/myapp-wildfly.jar
+java -jar target/myapp-bootable.jar
 ```
 
 To get the list of the startup arguments:
 
 ```
-java -jar target/myapp-wildfly.jar --help
+java -jar target/myapp-bootable.jar --help
 ```
 
 A WildFly bootable jar behave in a way that is similar to a WildFly server installed on file system:

--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -5,13 +5,13 @@ A WildFly bootable jar contains both the server and your packaged application (a
 Once the application has been built and packaged as a bootable jar, you can start the application using the following command:
 
 ```
-java -jar target/myapp-wildfly.jar
+java -jar target/myapp-bootable.jar
 ```
 
 To get the list of the startup arguments:
 
 ```
-java -jar target/myapp-wildfly.jar --help
+java -jar target/myapp-bootable.jar --help
 ```
 
 A WildFly bootable jar behave in a way that is similar to a WildFly server installed on file system:
@@ -148,7 +148,7 @@ The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/mast
 When starting an hollow jar you can provide the path to a deployment you want to see deployed inside the server. For example:
 
 ``
- java -jar target/jaxrs-hollow-server-wildfly.jar --deployment=path/to/my-jaxrs-app.war
+ java -jar target/jaxrs-hollow-server-bootable.jar --deployment=path/to/my-jaxrs-app.war
 ``
 
 NB: In order to have your deployment be located in the root context, name the war file _ROOT.war_.
@@ -321,7 +321,7 @@ When running a slim bootable jar, the default local maven repository is used to 
 This can be overriden by using the _-Dmaven.repo.local=<path to repository>_ when launching the server, for example:
 
 ```
-java -Dmaven.repo.local=/opt/maven/maven-repo -jar jaxrs-wildfly.jar
+java -Dmaven.repo.local=/opt/maven/maven-repo -jar jaxrs-bootable.jar
 ```
 
 #### Generating a maven local repository during packaging

--- a/examples/byteman/README.md
+++ b/examples/byteman/README.md
@@ -6,6 +6,6 @@ add -Djboss.modules.system.pkgs=org.jboss.byteman when launching the bootable ja
 * Download and install byteman
 * cd jaxrs
 * mvn clean package
-* java -javaagent:${BYTEMAN_HOME}/lib/byteman.jar=script:../byteman/byteman.btm -Djboss.modules.system.pkgs=org.jboss.byteman -jar target/jaxrs-wildfly.jar
+* java -javaagent:${BYTEMAN_HOME}/lib/byteman.jar=script:../byteman/byteman.btm -Djboss.modules.system.pkgs=org.jboss.byteman -jar target/jaxrs-bootable.jar
 * Access to the application: http://127.0.0.1:8080/hello
 * Instrumented class logs are printed.

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -7,7 +7,7 @@ Build and run
 =============
 
 * mvn package 
-* java -jar target/https-wildfly.jar
+* java -jar target/https-bootable.jar
 * https://127.0.0.1:8443/hello
 
 Openshift binary build and deployment
@@ -17,7 +17,7 @@ In this example, the keystore is not packaged in the bootable jar but mounted in
 
 Steps:
 * mvn package -Popenshift
-* mkdir os && cp target/https-wildfly.jar os/
+* mkdir os && cp target/https-bootable.jar os/
 * oc new-build --strategy source --binary --image-stream openjdk11 --name https-test
 * oc start-build https-test --from-dir ./os/
 * oc new-app https-test

--- a/examples/microprofile-config/README.adoc
+++ b/examples/microprofile-config/README.adoc
@@ -10,7 +10,7 @@ configure the application
 == Run the application locally
 
 * To build: `mvn package`
-* To run: `CONFIG1="Value comes from the env" java -jar target/microprofile-config-wildfly.jar`
+* To run: `CONFIG1="Value comes from the env" java -jar target/microprofile-config-bootable.jar`
 * Access the application: http://localhost:8080/
 
 [source,bash]
@@ -28,7 +28,7 @@ config3 = Default value for config3 comes from my code
 [source,bash]
 ----
 $ mvn package -Popenshift
-$ mkdir target/openshift && cp target/microprofile-config-wildfly.jar target/openshift
+$ mkdir target/openshift && cp target/microprofile-config-bootable.jar target/openshift
 # Import the OpenJDK 11 image to run the Java application
 $ oc import-image ubi8/openjdk-11 --from=registry.redhat.io/ubi8/openjdk-11 --confirm
 $ oc new-build --strategy source --binary --image-stream openjdk-11 --name microprofile-config-app

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -7,7 +7,7 @@ NB: postgresql server must be deployed in the cluster.
 
 Steps: 
 * mvn package -Popenshift
-* mkdir os && cp target/postgresql-wildfly.jar os/
+* mkdir os && cp target/postgresql-bootable.jar os/
 * oc new-build --strategy source --binary --image-stream openjdk11 --name wf-postgresql
 * oc start-build wf-postgresql --from-dir ./os/
 * oc new-app wf-postgresql

--- a/examples/secmanager/README.md
+++ b/examples/secmanager/README.md
@@ -3,6 +3,6 @@
 During packaging the permission to read properties is granted to deployments.
 
 * To build: mvn package
-* Update the file ./mypolicy codebase URL with absolute path to  target/sec-manager-wildfly.jar
-* To run: java -Djava.security.manager -Djava.security.policy=mypolicy -jar target/sec-manager-wildfly.jar
+* Update the file ./mypolicy codebase URL with absolute path to  target/sec-manager-bootable.jar
+* To run: java -Djava.security.manager -Djava.security.policy=mypolicy -jar target/sec-manager-bootable.jar
 * Access the application: http://127.0.0.1:8080/hello

--- a/examples/secmanager/mypolicy
+++ b/examples/secmanager/mypolicy
@@ -1,3 +1,3 @@
-grant codeBase "file:<path>/wildfly-jar-maven-plugin/examples/secmanager/target/sec-manager-wildfly.jar" {
+grant codeBase "file:<path>/wildfly-jar-maven-plugin/examples/secmanager/target/sec-manager-bootable.jar" {
  permission java.security.AllPermission;
 };

--- a/examples/slim/README.md
+++ b/examples/slim/README.md
@@ -1,5 +1,5 @@
 # WildFly slim bootable jar and local maven repository generation Example
 
 * To build: mvn package
-* To run: java -Dmaven.repo.local=\<absolute path to wildfly jar maven project\>/examples/slim/my-maven-repo -jar target/slim-wildfly.jar
+* To run: java -Dmaven.repo.local=\<absolute path to wildfly jar maven project\>/examples/slim/my-maven-repo -jar target/slim-bootable.jar
 * Access the application: http://127.0.0.1:8080/hello

--- a/examples/web-clustering/README.md
+++ b/examples/web-clustering/README.md
@@ -1,8 +1,8 @@
 # Web session sharing between multiple bootable JAR instances example
 
 * To build: mvn package
-* To run first instance: java -jar target/web-clustering-wildfly.jar -Djboss.socket.binding.port-offset=10 -Djboss.node.name=node1
-* To run second instance: java -jar target/web-clustering-wildfly.jar -Djboss.node.name=node2
+* To run first instance: java -jar target/web-clustering-bootable.jar -Djboss.socket.binding.port-offset=10 -Djboss.node.name=node1
+* To run second instance: java -jar target/web-clustering-bootable.jar -Djboss.node.name=node2
 * Access the application running in the first instance: http://127.0.0.1:8080
 * Note sessionID and user creation time.
 * Kill first instance
@@ -20,7 +20,7 @@ Openshift binary build and deployment
 
 Steps:
 * mvn package -Popenshift
-* mkdir os && cp target/web-clustering-wildfly.jar os/
+* mkdir os && cp target/web-clustering-bootable.jar os/
 * oc policy add-role-to-user view system:serviceaccount:$(oc project -q):default
 * oc new-build --strategy source --binary --image-stream openjdk11 --name web-clustering
 * oc start-build web-clustering --from-dir ./os/

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
@@ -99,7 +99,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 class AbstractBuildBootableJarMojo extends AbstractMojo {
 
-    public static final String BOOTABLE_SUFFIX = "wildfly";
+    public static final String BOOTABLE_SUFFIX = "bootable";
     public static final String JAR = "jar";
     public static final String WAR = "war";
     private static final String MODULE_ID_JAR_RUNTIME = "org.wildfly.bootable-jar";
@@ -224,7 +224,7 @@ class AbstractBuildBootableJarMojo extends AbstractMojo {
     boolean skip;
 
     /**
-     * By default the generated jar is ${project.build.finalName}-wildfly.jar
+     * By default the generated jar is ${project.build.finalName}-bootable.jar
      */
     @Parameter(alias = "output-file-name", property = "wildfly.bootable.package.output.file.name")
     String outputFileName;

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootableJarMojoTestCase.java
@@ -49,7 +49,7 @@ public class BootableJarMojoTestCase extends AbstractConfiguredMojoTestCase {
 
     private static final String WILDFLY_VERSION = "version.wildfly";
     private static final String TEST_REPLACE = "TEST_REPLACE";
-
+    private static final String TEST_FILE = "test-" + AbstractBuildBootableJarMojo.BOOTABLE_SUFFIX + ".jar";
     private static Path TEST_DIR = null;
     private static Path setupProject(String pomFileName, boolean copyWar, String provisioning, String... cli) throws IOException {
         File pom = getTestFile("src/test/resources/poms/" + pomFileName);
@@ -288,7 +288,7 @@ public class BootableJarMojoTestCase extends AbstractConfiguredMojoTestCase {
             assertNotNull(mojo);
             System.setProperty("dev", "");
             mojo.execute();
-            assertFalse(Files.exists(dir.resolve("target").resolve("test-wildfly.jar")));
+            assertFalse(Files.exists(dir.resolve("target").resolve(TEST_FILE)));
             assertTrue(Files.exists(dir.resolve("target").resolve("deployments").resolve("ROOT.war")));
         } finally {
             System.clearProperty("dev");
@@ -305,7 +305,7 @@ public class BootableJarMojoTestCase extends AbstractConfiguredMojoTestCase {
             assertNotNull(mojo);
             assertTrue(mojo.skip);
             mojo.execute();
-            assertFalse(Files.exists(dir.resolve("target").resolve("test-wildfly.jar")));
+            assertFalse(Files.exists(dir.resolve("target").resolve(TEST_FILE)));
         } finally {
             BuildBootableJarMojo.deleteDir(dir);
         }
@@ -353,9 +353,9 @@ public class BootableJarMojoTestCase extends AbstractConfiguredMojoTestCase {
     private void checkJar(Path dir, boolean expectDeployment, boolean isRoot,
             String[] layers, String[] excludedLayers, String... configTokens) throws Exception {
         Path tmpDir = Files.createTempDirectory("bootable-jar-test-unzipped");
-        Path wildflyHome = Files.createTempDirectory("bootable-jar-test-unzipped-wildfly");
+        Path wildflyHome = Files.createTempDirectory("bootable-jar-test-unzipped-" + AbstractBuildBootableJarMojo.BOOTABLE_SUFFIX);
         try {
-            Path jar = dir.resolve("target").resolve("test-wildfly.jar");
+            Path jar = dir.resolve("target").resolve(TEST_FILE);
             assertTrue(Files.exists(jar));
 
             ZipUtils.unzip(jar, tmpDir);
@@ -444,7 +444,7 @@ public class BootableJarMojoTestCase extends AbstractConfiguredMojoTestCase {
     }
 
     private void startServer(Path dir, String fileName, String... args) throws Exception {
-        String[] cmd = {"java", "-jar", dir.resolve("target").resolve(fileName == null ? "test-wildfly.jar" : fileName).toString()};
+        String[] cmd = {"java", "-jar", dir.resolve("target").resolve(fileName == null ? TEST_FILE : fileName).toString()};
         List<String> arguments = new ArrayList<>();
         arguments.addAll(Arrays.asList(cmd));
         arguments.addAll(Arrays.asList(args));


### PR DESCRIPTION
Fix for issue https://github.com/wildfly-extras/wildfly-jar-maven-plugin/issues/30
Replaced -wildfly suffix with -bootable.