### PR TITLE
Add list of sub modules as Eclipe will only recursively import modules referenced from the parent.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -93,6 +93,24 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <modules>
+        <module>byteman</module>
+        <module>dev-mode</module>
+        <module>hollow-jar</module>
+        <module>https</module>
+        <module>jaxrs</module>
+        <module>jib</module>
+        <module>jib-layers</module>
+        <module>jib-operator</module>
+        <module>logging</module>
+        <module>microprofile-config</module>
+        <module>postgresql</module>
+        <module>secmanager</module>
+        <module>slim</module>
+        <module>web-clustering</module>
+    </modules>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Working with Eclipse it was only possible to import the modules one by one as there was no reference from their parent.

I haven't added the examples module to the module list of the overall parent as I believe that would mean every module will be rebuilt each time the project is built.