### PR TITLE
Issue#44 Adjust example to use the -secmgr argument to activate the SecurityManager

### DIFF
--- a/examples/scripts/deployment-permissions.cli
+++ b/examples/scripts/deployment-permissions.cli
@@ -1,1 +1,0 @@
-/subsystem=security-manager/deployment-permissions=default:write-attribute(name=minimum-permissions, value=[{class="java.util.PropertyPermission", actions="read", name="*"}])

--- a/examples/secmanager/README.md
+++ b/examples/secmanager/README.md
@@ -4,4 +4,6 @@ During packaging the permission to read properties is granted to deployments.
 
 * To build: mvn package
 * To run: java -jar target/sec-manager-bootable.jar -secmgr
-* Access the application: http://127.0.0.1:8080/hello
+* Access the application: 
+    * http://127.0.0.1:8080/hello/read  - Should succeed as the read action is allowed.
+    * http://127.0.0.1:8080/hello/write - Should fail with an `AccessControlException` as the write permission was not granted. 

--- a/examples/secmanager/README.md
+++ b/examples/secmanager/README.md
@@ -3,6 +3,5 @@
 During packaging the permission to read properties is granted to deployments.
 
 * To build: mvn package
-* Update the file ./mypolicy codebase URL with absolute path to  target/sec-manager-bootable.jar
-* To run: java -Djava.security.manager -Djava.security.policy=mypolicy -jar target/sec-manager-bootable.jar
+* To run: java -jar target/sec-manager-bootable.jar -secmgr
 * Access the application: http://127.0.0.1:8080/hello

--- a/examples/secmanager/mypolicy
+++ b/examples/secmanager/mypolicy
@@ -1,3 +1,0 @@
-grant codeBase "file:<path>/wildfly-jar-maven-plugin/examples/secmanager/target/sec-manager-bootable.jar" {
- permission java.security.AllPermission;
-};

--- a/examples/secmanager/pom.xml
+++ b/examples/secmanager/pom.xml
@@ -29,6 +29,10 @@
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
                 <configuration >
                     <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                    <layers>
+                        <layer>security-manager</layer>
+                        <layer>web-server</layer>
+                    </layers>
                 </configuration>
                 <executions>
                     <execution>

--- a/examples/secmanager/pom.xml
+++ b/examples/secmanager/pom.xml
@@ -29,16 +29,6 @@
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
                 <configuration >
                     <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
-                    <cli-sessions>
-                        <cli-session>
-                            <properties-file>
-                                ../scripts/cli.properties
-                            </properties-file>
-                            <script-files>
-                                <script>../scripts/deployment-permissions.cli</script>
-                            </script-files>
-                        </cli-session>
-                    </cli-sessions>
                 </configuration>
                 <executions>
                     <execution>

--- a/examples/secmanager/pom.xml
+++ b/examples/secmanager/pom.xml
@@ -31,7 +31,7 @@
                     <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
                     <layers>
                         <layer>security-manager</layer>
-                        <layer>web-server</layer>
+                        <layer>jaxrs</layer>
                     </layers>
                 </configuration>
                 <executions>

--- a/examples/secmanager/src/main/java/com/example/demo/rest/HelloWorldEndpoint.java
+++ b/examples/secmanager/src/main/java/com/example/demo/rest/HelloWorldEndpoint.java
@@ -6,13 +6,22 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 
-
 @Path("/hello")
 public class HelloWorldEndpoint {
+
     @GET
+    @Path("/read")
     @Produces("text/plain")
-    public Response doGet() {
+    public Response read() {
         System.getProperty("FOO");
-        return Response.ok("Hello from WildFly bootable jar!").build();
+        return Response.ok("Successfully read system property \"FOO\"").build();
+    }
+
+    @GET
+    @Path("/write")
+    @Produces("text/plain")
+    public Response write() {
+        System.setProperty("FOO", "VALUE");
+        return Response.ok("Successfully write system property \"FOO\"").build();
     }
 }

--- a/examples/secmanager/src/main/webapp/META-INF/permissions.xml
+++ b/examples/secmanager/src/main/webapp/META-INF/permissions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<permissions version="7" xmlns="http://xmlns.jcp.org/xml/ns/javaee">
+    <permission xmlns="">
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+        <actions>read</actions>
+    </permission>
+</permissions>


### PR DESCRIPTION
This update will be dependent on a WildFly release containing this PR https://github.com/wildfly/wildfly-core/pull/4301

This does also include a commit from PR https://github.com/wildfly-extras/wildfly-jar-maven-plugin/pull/45 but the first PR can go in as is and this follow once WildFly is available.
