### PR TITLE
Replace in the path on Windows single backslash with double backslash.

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevBootableJarMojo.java
@@ -19,6 +19,8 @@ package org.wildfly.plugins.bootablejar.maven.goals;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -64,7 +66,7 @@ public final class DevBootableJarMojo extends AbstractBuildBootableJarMojo {
     }
 
     private void configureScanner(Path deployments, List<String> commands) {
-        String deploymentPath = deployments.toString().replaceAll("\\x5c", "/");
+        String deploymentPath = deployments.toString().replaceAll("\\\\", "\\\\\\\\");
         commands.add("/subsystem=deployment-scanner/scanner=" + DEPLOYMENT_SCANNER_NAME + ":add(scan-interval=1000,auto-deploy-exploded=false,"
                 + "path=\"" + deploymentPath + "\")");
     }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevBootableJarMojo.java
@@ -64,7 +64,8 @@ public final class DevBootableJarMojo extends AbstractBuildBootableJarMojo {
     }
 
     private void configureScanner(Path deployments, List<String> commands) {
+        String deploymentPath = deployments.toString().replaceAll("\\x5c", "/");
         commands.add("/subsystem=deployment-scanner/scanner=" + DEPLOYMENT_SCANNER_NAME + ":add(scan-interval=1000,auto-deploy-exploded=false,"
-                + "path=\"" + deployments + "\")");
+                + "path=\"" + deploymentPath + "\")");
     }
 }


### PR DESCRIPTION
If on Windows replace path separator with double backslash for deployments path.

If not replaced redeployment fails because deployment scanner treats windows path separator as escape character in the path string and the resulting path is invalid.

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>