### PR TITLE
Fixes for DevServerTestCase

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -97,6 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
                 <!--
                     This is required for tests to run successfully on Windows and run properly in general. The issue
                     being is the MOJO will initialize JBoss Modules in the JVM. Once this happens and a module is loaded

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -164,7 +164,9 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
             if (expectDeployment) {
                 assertEquals(1, Files.list(wildflyHome.resolve("standalone/data/content")).count());
             } else {
-                assertFalse(Files.exists(wildflyHome.resolve("standalone/data/content")));
+                if (Files.exists(wildflyHome.resolve("standalone/data/content"))) {
+                    assertEquals(0, Files.list(wildflyHome.resolve("standalone/data/content")).count());
+                }
             }
             Path history = wildflyHome.resolve("standalone").resolve("configuration").resolve("standalone_xml_history");
             assertFalse(Files.exists(history));
@@ -188,8 +190,8 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
                 }
             }
             if (configTokens != null) {
+                String str = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
                 for (String token : configTokens) {
-                    String str = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
                     assertTrue(str.contains(token));
                 }
             }

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
@@ -20,13 +20,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author jdenise
  */
-@Ignore("Can't run, we can't call start from the mvn tests, break tests.")
 public class DevServerTestCase extends AbstractBootableJarMojoTestCase {
 
     public DevServerTestCase() {
@@ -41,12 +39,17 @@ public class DevServerTestCase extends AbstractBootableJarMojoTestCase {
         assertEquals("deployment-scanner", mojo.excludedLayers.get(0));
         mojo.execute();
         final Path dir = getTestDir();
-        checkJar(dir, false, false, null, null, "target/deployments");
-        Path config = dir.resolve("target").resolve("bootable-jar-build-artifacts").
+        try {
+            checkJar(dir, false, false, null, null, "target" + System.getProperty("file.separator") + "deployments");
+            Path config = dir.resolve("target").resolve("bootable-jar-build-artifacts").
                 resolve("wildfly").resolve("standalone").resolve("configuration").resolve("standalone.xml");
-        assertTrue(Files.exists(config));
-        String content = new String(Files.readAllBytes(dir), StandardCharsets.UTF_8);
-        assertTrue(content.contains(DevBootableJarMojo.DEPLOYMENT_SCANNER_NAME));
+            assertTrue(Files.exists(config));
+            String content = new String(Files.readAllBytes(config), StandardCharsets.UTF_8);
+            assertTrue(content.contains(DevBootableJarMojo.DEPLOYMENT_SCANNER_NAME));
+        } catch (Throwable t) {
+            shutdownServer(dir);
+            throw t;
+        }
         checkManagementItf(dir, false);
     }
 }


### PR DESCRIPTION
This PR enables DevServerTestCase. 

All code that performs checks against running server is placed in try/catch block which shuts down the server in case of error. 
The content of the configuration file was incorrectly read from **dir** instead of **config**.

The check for target/deployments was hard coded with unix separator. 

In order to pass this test needs the changes from previous PR about replacing single backslash with double backslash on windows. 

On Unix it should work without that change.

I've also changed the check when no content is expected to look for 0 files instead of missing content directory. That directory is created as soon as CLI script is executed. 

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>