### PR TITLE
[#59] Bootable JAR to contain galleon metadata to understand provisio…

### DIFF
--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -160,6 +160,9 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
             Path zippedWildfly = tmpDir.resolve("wildfly.zip");
             assertTrue(Files.exists(zippedWildfly));
 
+            Path provisioningFile = tmpDir.resolve("provisioning.xml");
+            assertTrue(Files.exists(provisioningFile));
+
             ZipUtils.unzip(zippedWildfly, wildflyHome);
             if (expectDeployment) {
                 assertEquals(1, Files.list(wildflyHome.resolve("standalone/data/content")).count());


### PR DESCRIPTION
This is the plugin part of this fix. Make provisioning.xml present at the root of the JAR. The --display-galleon-config option is handled by https://issues.redhat.com/browse/WFCORE-5097