### PR TITLE
[#56] Change the output to a file in the dev mode goal for the created process

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>wildfly-cli</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-plugin-core</artifactId>
         </dependency>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/RunBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/RunBootableJarMojo.java
@@ -26,6 +26,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.wildfly.core.launcher.BootableJarCommandBuilder;
+import org.wildfly.core.launcher.Launcher;
 import org.wildfly.plugins.bootablejar.maven.common.Utils;
 
 /**
@@ -97,8 +99,14 @@ public final class RunBootableJarMojo extends AbstractMojo {
                 this.arguments.add(args.nextToken());
             }
         }
-
-        Utils.startBootableJar(Utils.getBootableJarPath(jarFileName, project, "run"), jvmArguments, arguments, true,
-                false, null, -1);
+        try {
+            final BootableJarCommandBuilder commandBuilder = BootableJarCommandBuilder.of(Utils.getBootableJarPath(jarFileName, project, "run"))
+                    .addJavaOptions(jvmArguments)
+                    .addServerArgument(argumentsProps);
+            final Process process = Launcher.of(commandBuilder).launch();
+            process.waitFor();
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getLocalizedMessage(), e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <version.org.apache.maven.plugin-tools>3.5.1</version.org.apache.maven.plugin-tools>
     <version.org.asciidoctor>2.0.0</version.org.asciidoctor>
     <version.org.jboss.galleon>4.2.5.Final</version.org.jboss.galleon>
-    <version.org.wildfly.core.wildfly-core>13.0.0.Beta2</version.org.wildfly.core.wildfly-core>
+    <version.org.wildfly.core.wildfly-core>13.0.0.Beta5</version.org.wildfly.core.wildfly-core>
     <version.org.wildfly.plugins.wildfly-maven-plugin>2.0.1.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
     <!-- required by tests -->
     <version.org.apache.httpcomponents.httpclient>4.5.11</version.org.apache.httpcomponents.httpclient>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-launcher</artifactId>
+        <version>${version.org.wildfly.core.wildfly-core}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.galleon</groupId>
         <artifactId>galleon-maven-plugin</artifactId>
         <version>${version.org.jboss.galleon}</version>

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -167,7 +167,11 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
             if (expectDeployment) {
                 assertEquals(1, Files.list(wildflyHome.resolve("standalone/data/content")).count());
             } else {
-                assertFalse(Files.exists(wildflyHome.resolve("standalone/data/content")));
+                // The directory should be empty if no deployment is expected, however in some cases it may not even be
+                // created.
+                if (Files.exists(wildflyHome.resolve("standalone/data/content"))) {
+                    assertEquals(0, Files.list(wildflyHome.resolve("standalone/data/content")).count());
+                }
             }
             Path history = wildflyHome.resolve("standalone").resolve("configuration").resolve("standalone_xml_history");
             assertFalse(Files.exists(history));
@@ -191,8 +195,8 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
                 }
             }
             if (configTokens != null) {
+                String str = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
                 for (String token : configTokens) {
-                    String str = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
                     assertTrue(str.contains(token));
                 }
             }

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
@@ -16,17 +16,16 @@
  */
 package org.wildfly.plugins.bootablejar.maven.goals;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author jdenise
  */
-@Ignore("Can't run, we can't call start from the mvn tests, break tests.")
 public class DevServerTestCase extends AbstractBootableJarMojoTestCase {
 
     public DevServerTestCase() {
@@ -41,11 +40,11 @@ public class DevServerTestCase extends AbstractBootableJarMojoTestCase {
         assertEquals("deployment-scanner", mojo.excludedLayers.get(0));
         mojo.execute();
         final Path dir = getTestDir();
-        checkJar(dir, false, false, null, null, "target/deployments");
+        checkJar(dir, false, false, null, null, "target" + File.separator + "deployments");
         Path config = dir.resolve("target").resolve("bootable-jar-build-artifacts").
                 resolve("wildfly").resolve("standalone").resolve("configuration").resolve("standalone.xml");
         assertTrue(Files.exists(config));
-        String content = new String(Files.readAllBytes(dir), StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(config), StandardCharsets.UTF_8);
         assertTrue(content.contains(DevBootableJarMojo.DEPLOYMENT_SCANNER_NAME));
         checkManagementItf(dir, false);
     }


### PR DESCRIPTION
This resolves #56. The `stdout` and `stderr` are written to a file instead of being inherited by the parent process. This also, with some minor changes, allows the `DevServerTestCase` to be re-enabled.

I also removed the utility to start the bootable JAR in favor of the `BootableJarCommandBuilder` in WildFly Core. As part of this I have a commit which upgrades WildFly Core to 13.0.0.Beta5 which was released yesterday.