### PR TITLE
Fix for WFWIP-330, Bootable JAR - Cloud - No HA support in default configuration

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -218,6 +218,7 @@ Set the cloud child element ```<type>openshift|kubernetes</type>``` to select th
 
 The sever configuration is updated in order to properly operate in a cloud environment:
 
+* If no Galleon layers are provisioned, the provisioned configuration is ```standalone-microprofile-ha.xml``` instead of ```standalone-microprofile.xml```.
 * The ```microprofile-health``` and ```core-tools``` (that contains WildFly CLI) galleon layers are provisioned. They are required for the  OpenShift probes and WildFly OpenShift operator to properly operate.
 * The public and private inet addresses are bound to the value of the ```HOSTNAME``` environment variable if defined (defined in OpenShift PODS).
 * The management inet address is bound to the 0.0.0.0 inet address allowing for local (required by WildFly CLI) and remote access (required by OpenShift readiness and liveness probes).

--- a/examples/hollow-jar/README.md
+++ b/examples/hollow-jar/README.md
@@ -1,6 +1,15 @@
 # WildFly bootable hollow jar example
 
-Build a bootable jar containing  no deployment.
+Build a bootable JAR containing no deployment for both bare-metal and OpenShift.
 
 * To build: mvn package
 * To run: mvn wildfly-jar:run
+
+To build the bootable JAR for OpenShift:
+
+* mvn package -Popenshift
+
+When building a bootable JAR for OpenShift, a set of WildFly CLI commands are applied to the server configuration in order to
+adjust it to the OpenShift context. The applied script can be retrieved in target/bootable-jar-build-artifacts/generated-cli-script.txt file.
+
+You can check community documentation to retrieve information on the cloud specific changes.

--- a/examples/hollow-jar/pom.xml
+++ b/examples/hollow-jar/pom.xml
@@ -8,10 +8,10 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <artifactId>jaxrs-hollow-server</artifactId>
+    <artifactId>default-hollow-jar</artifactId>
     <packaging>pom</packaging>
     
-    <name>WildFly bootable jar Jaxrs hollow server</name>
+    <name>WildFly bootable JAR default Eclipse Microprofile configuration hollow JAR</name>
    
    
     <build>
@@ -22,13 +22,6 @@
                 <artifactId>wildfly-jar-maven-plugin</artifactId>   
                 <configuration>
                     <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
-                    <layers>
-                        <layer>jaxrs</layer>
-                        <layer>management</layer>
-                    </layers>
-                    <excluded-layers>
-                        <layer>deployment-scanner</layer>
-                    </excluded-layers>
                     <hollow-jar>true</hollow-jar>
                 </configuration>
                 <executions>
@@ -41,4 +34,21 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>openshift</id>
+            <build>
+                <finalName>${project.artifactId}</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>   
+                        <configuration>
+                            <cloud/>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.jboss.galleon.config.ConfigId;
 
 /**
  * Build a bootable jar containing application and provisioned server
@@ -51,6 +52,7 @@ public final class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
             return;
         }
         if (cloud != null) {
+            getLog().info("Cloud support is enabled");
             cloud.validate();
             for(String layer : cloud.getExtraLayers(this)) {
                 addExtraLayer(layer);
@@ -67,6 +69,15 @@ public final class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
+        }
+    }
+
+    @Override
+    protected ConfigId getDefaultConfig() {
+        if(cloud == null) {
+            return super.getDefaultConfig();
+        } else {
+            return new ConfigId("standalone", "standalone-microprofile-ha.xml");
         }
     }
 

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -203,7 +203,7 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
             if (configTokens != null) {
                 String str = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
                 for (String token : configTokens) {
-                    assertTrue(str.contains(token));
+                    assertTrue(str, str.contains(token));
                 }
             }
         } finally {

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+/**
+ * @author jdenise
+ */
+public class DefaultCloudConfigurationTestCase extends AbstractBootableJarMojoTestCase {
+
+    public DefaultCloudConfigurationTestCase() {
+        super("test13-pom.xml", true, null);
+    }
+
+    @Test
+    public void testDefaultConfiguration()
+            throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        assertNotNull(mojo);
+        assertTrue(mojo.cliSessions.isEmpty());
+        assertTrue(mojo.featurePackLocation.startsWith("wildfly@maven(org.jboss.universe:community-universe)#"));
+        assertNotNull(mojo.projectBuildDir);
+        assertTrue(mojo.excludedLayers.isEmpty());
+        assertTrue(mojo.layers.isEmpty());
+        assertTrue(mojo.pluginOptions.isEmpty());
+        assertFalse(mojo.hollowJar);
+        assertFalse(mojo.logTime);
+        assertFalse(mojo.offline);
+        assertFalse(mojo.recordState);
+        assertFalse(mojo.skip);
+        assertTrue(mojo.rootUrlPath);
+        mojo.execute();
+        final Path dir = getTestDir();
+        checkJar(dir, true, true, null, null, "org.jboss.as.clustering.jgroups");
+        checkDeployment(dir, true);
+    }
+}

--- a/tests/src/test/resources/poms/test13-pom.xml
+++ b/tests/src/test/resources/poms/test13-pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test1</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly bootable jar Example for tests</name>
+    
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#TEST_REPLACE</feature-pack-location>
+                    <cloud/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFWIP-330

* When cloud is enabled, generate standalone-microprofile-ha.xml configuration.
* Store generated/applied CLI script to build artifacts.
* New unit test for default cloud config.
* Reworked Hollow example to provision both bare-metal and cloud default configuration. We were missing an example for default config and introducing a new one would be too much. Provisioning galleon layers in Hollow jar example was not bringing that much, all other examples provision galleon layers.