### PR TITLE
Fix for WFWIP-343, FeaturePack element exposes misleading Galleon concepts

### DIFF
--- a/examples/postgresql/pom.xml
+++ b/examples/postgresql/pom.xml
@@ -52,15 +52,11 @@
                     <feature-packs>
                         <feature-pack>
                             <location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</location>
-                            <inherit-configs>false</inherit-configs>
-                            <inherit-packages>false</inherit-packages>
                         </feature-pack>
                         <feature-pack>
                             <groupId>org.wildfly</groupId>
                             <artifactId>wildfly-datasources-galleon-pack</artifactId>
                             <version>1.0.6.Final</version>
-                            <inherit-configs>false</inherit-configs>
-                            <inherit-packages>false</inherit-packages>
                         </feature-pack>
                     </feature-packs>
                     <layers>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/FeaturePack.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/FeaturePack.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.common;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.shared.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.dependencies.DependableCoordinate;
+import org.jboss.galleon.util.StringUtils;
+
+/**
+ * Copied from Galleon plugin and simplified to cope with bootable JAR.
+ *
+ * @author JF Denise
+ * @author Alexey Loubyanssky
+ */
+public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String type = "zip";
+    private String classifier;
+    private String extension = "zip";
+
+    private String location;
+
+    private String includedDefaultConfig;
+
+    private Boolean inheritPackages = false;
+    private List<String> excludedPackages = Collections.emptyList();
+    private List<String> includedPackages = Collections.emptyList();
+
+    private Path path;
+
+    @Override
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        assertGalleon1Location();
+        this.groupId = groupId;
+    }
+
+    @Override
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        assertGalleon1Location();
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        assertGalleon1Location();
+        this.version = version;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        assertGalleon1Location();
+        this.type = type;
+    }
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public void setClassifier(String classifier) {
+        assertGalleon1Location();
+        this.classifier = classifier;
+    }
+
+    @Override
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        assertGalleon1Location();
+        this.extension = extension;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        assertGalleon2Location();
+        this.location = location;
+    }
+
+    public Boolean isInheritPackages() {
+        return inheritPackages;
+    }
+
+    public void setInheritPackages(boolean inheritPackages) {
+        this.inheritPackages = inheritPackages;
+    }
+
+    public String getIncludedDefaultConfig() {
+        return includedDefaultConfig;
+    }
+
+    public void setIncludedConfigs(String includedDefaultConfig) {
+        this.includedDefaultConfig = includedDefaultConfig;
+    }
+
+    public List<String> getExcludedPackages() {
+        return excludedPackages;
+    }
+
+    public void setExcludedPackages(List<String> excludedPackages) {
+        this.excludedPackages = excludedPackages;
+    }
+
+    public List<String> getIncludedPackages() {
+        return includedPackages;
+    }
+
+    public void setIncludedPackages(List<String> includedPackages) {
+        this.includedPackages = includedPackages;
+    }
+
+    public void setPath(File path) {
+        assertPathLocation();
+        this.path = path.toPath().normalize();
+    }
+
+    public Path getNormalizedPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append('{');
+        if (location != null) {
+            buf.append(location);
+        } else {
+            buf.append(groupId).append(':').append(artifactId).append(':').append(version);
+        }
+        buf.append(" inherit-packages=").append(inheritPackages);
+        if (!includedPackages.isEmpty()) {
+            buf.append(" included-packages=");
+            StringUtils.appendList(buf, includedPackages);
+        }
+        if (!excludedPackages.isEmpty()) {
+            buf.append(" excluded-packages=");
+            StringUtils.appendList(buf, excludedPackages);
+        }
+        if (includedDefaultConfig != null) {
+            buf.append(" included-default-config=");
+            buf.append(includedDefaultConfig);
+        }
+        return buf.append('}').toString();
+    }
+
+    private void assertPathLocation() {
+        if (groupId != null || artifactId != null || version != null) {
+            throw new IllegalStateException("feature-pack Path cannot be used: Galleon 1.x feature-pack Maven coordinates have already been initialized");
+        }
+        if (location != null) {
+            throw new IllegalStateException("feature-pack Path cannot be used: Galleon 2.x location has already been initialized");
+        }
+    }
+
+    private void assertGalleon2Location() {
+        if (groupId != null || artifactId != null || version != null) {
+            throw new IllegalStateException("Galleon 2.x location cannot be used: feature-pack Maven coordinates have already been initialized");
+        }
+        if (path != null) {
+            throw new IllegalStateException("Galleon 2.x location cannot be used: feature-pack Path has already been initialized");
+        }
+    }
+
+    private void assertGalleon1Location() {
+        if (location != null) {
+            throw new IllegalStateException("Galleon 1.x feature-pack Maven coordinates cannot be used: Galleon 2.x feature-pack location has already been initialized");
+        }
+        if (path != null) {
+            throw new IllegalStateException("Galleon 1.x feature-pack Maven coordinates cannot be used: feature-pack Path has already been initialized");
+        }
+    }
+}

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -102,14 +102,15 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
 
     @Override
     protected Mojo lookupConfiguredMojo(File pom, String goal) throws Exception {
-        Mojo mojo = super.lookupConfiguredMojo(pom, goal);
-        if (mojo instanceof AbstractBuildBootableJarMojo) {
-            AbstractBuildBootableJarMojo buildMojo = (AbstractBuildBootableJarMojo) mojo;
-            if (buildMojo.featurePackLocation != null) {
-                int i = buildMojo.featurePackLocation.lastIndexOf("#");
-                buildMojo.featurePackLocation = buildMojo.featurePackLocation.substring(0, i + 1) + System.getProperty(WILDFLY_VERSION);
+        StringBuilder content = new StringBuilder();
+        for (String s : Files.readAllLines(pom.toPath())) {
+            if (s.contains(TEST_REPLACE)) {
+                s = s.replace(TEST_REPLACE, System.getProperty(WILDFLY_VERSION));
             }
+            content.append(s).append(System.lineSeparator());
         }
+        Files.write(pom.toPath(), content.toString().getBytes());
+        Mojo mojo = super.lookupConfiguredMojo(pom, goal);
         return mojo;
     }
 

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+/**
+ * @author jdenise
+ */
+public class IncludedDefaultConfigurationTestCase extends AbstractBootableJarMojoTestCase {
+
+    public IncludedDefaultConfigurationTestCase() {
+        super("test12-pom.xml", true, null);
+    }
+
+    @Test
+    public void testLayersConfiguration() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        assertNotNull(mojo);
+        assertFalse(mojo.excludedLayers.isEmpty());
+        assertEquals(1, mojo.excludedLayers.size());
+        assertEquals("h2-default-datasource", mojo.excludedLayers.get(0));
+        mojo.recordState = true;
+        mojo.execute();
+        String[] excludedLayers = {"h2-default-datasource"};
+        final Path dir = getTestDir();
+        checkJar(dir, true, true, null, excludedLayers);
+        checkDeployment(dir, true);
+    }
+}

--- a/tests/src/test/resources/poms/test12-pom.xml
+++ b/tests/src/test/resources/poms/test12-pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test2</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly bootable jar Example for tests</name>
+
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>wildfly@maven(org.jboss.universe:community-universe)#TEST_REPLACE</location>
+                            <included-default-config>standalone-microprofile.xml</included-default-config>
+                        </feature-pack>
+                    </feature-packs>
+                    <excluded-layers>
+                        <layer>h2-default-datasource</layer>
+                    </excluded-layers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFWIP-343

* Remove inherit-configs item. It is implicitly false.
* Make inherit-packages false by default.
* Remove included-configs and excluded-configs elements. In a bootable JAR context a single configuration can be included.
* Introduce "included-default-config"=[name of included config, eg:standalone-microprofile.xml]. Used to identify the default configuration to include in the bootable JAR. 
* Remove transitive attribute.

Added unit test to cover layer exclusion from included default configuration.