### PR TITLE
Fix for WFWIP-346, Second bootable JAR fails to package if first uses certain layers

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -51,10 +51,6 @@
             <artifactId>galleon-maven-plugin</artifactId>
         </dependency>
         <dependency>
-          <groupId>org.wildfly.core</groupId>
-          <artifactId>wildfly-patching</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
@@ -67,15 +63,17 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-cli</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-plugin-core</artifactId>
+            <exclusions>
+              <exclusion>
+                    <groupId>org.jboss.modules</groupId>
+                    <artifactId>jboss-modules</artifactId>
+              </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wildfly.plugins</groupId>
@@ -85,13 +83,34 @@
                     <groupId>org.apache.maven</groupId>
                     <artifactId>maven-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.modules</groupId>
+                    <artifactId>jboss-modules</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-cli</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -123,6 +142,35 @@
                         <goals>
                             <goal>testResources</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${version.enforcer.plugin}</version>
+                <executions>
+                    <execution>
+                        <id>ban-bad-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <!-- we don't want these in the plugin classpath -->
+                                        <exclude>org.jboss.modules:jboss-modules</exclude>
+                                        <exclude>org.wildfly.core:wildfly-cli</exclude>
+                                        <exclude>org.wildfly.core:wildfly-embedded</exclude>
+                                        <exclude>org.wildfly.core:wildfly-patching</exclude>
+                                        <!-- should be banned but needed by tests -->
+                                        <!--<exclude>org.jboss.logmanager:jboss-logmanager</exclude>-->
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
@@ -92,7 +92,7 @@ public class CloudConfig {
         try (FileOutputStream s = new FileOutputStream(marker.toFile())) {
             props.store(s, type + " properties");
         }
-        Path extensionJar = mojo.resolveArtifact("org.wildfly.plugins", "wildfly-jar-cloud-extension", mojo.retrievePluginVersion());
+        Path extensionJar = mojo.resolveArtifact("org.wildfly.plugins", "wildfly-jar-cloud-extension", null, mojo.retrievePluginVersion());
         ZipUtils.unzip(extensionJar, contentDir);
     }
 

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/CLIExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/CLIExecutor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.logging.Level;
+import org.apache.maven.artifact.Artifact;
+import org.jboss.as.controller.client.ModelControllerClient;
+
+/**
+ * A CLI executor, resolving CLI classes from an URL Classloader. We can't have
+ * cli/embedded/jboss modules in plugin classpath, it causes issue because we
+ * are sharing the same jboss module classes between execution run inside the
+ * same JVM.
+ *
+ * CLI dependencies are retrieved from provisioned server artifacts list and
+ * resolved using maven. In addition jboss-modules.jar located in the
+ * provisioned server * is added.
+ *
+ * @author jdenise
+ */
+class CLIExecutor implements AutoCloseable {
+
+    private final Level level;
+    private final Object ctx;
+    private final Method handle;
+    private final Method terminateSession;
+    private final Method getModelControllerClient;
+    private final ClassLoader originalCl;
+    private final URLClassLoader cliCl;
+    private final String origConfig;
+    private final AbstractBuildBootableJarMojo mojo;
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    CLIExecutor(Path jbossHome, Set<Artifact> cliArtifacts,
+            AbstractBuildBootableJarMojo mojo, boolean resolveExpression) throws Exception {
+        this.mojo = mojo;
+        level = mojo.disableLog();
+        Path config = jbossHome.resolve("bin").resolve("jboss-cli.xml");
+        origConfig = System.getProperty("jboss.cli.config");
+        if (Files.exists(config)) {
+            System.setProperty("jboss.cli.config", config.toString());
+        }
+
+
+        final URL[] cp = new URL[cliArtifacts.size() + 1];
+        cp[0] = jbossHome.resolve("jboss-modules.jar").toUri().toURL();
+        mojo.getLog().debug("CLI artifacts " + cliArtifacts);
+        Iterator<Artifact> it = cliArtifacts.iterator();
+        int i = 1;
+        while (it.hasNext()) {
+            cp[i] = mojo.resolveArtifact(it.next()).toUri().toURL();
+            i += 1;
+        }
+        originalCl = Thread.currentThread().getContextClassLoader();
+        cliCl = new URLClassLoader(cp, originalCl);
+        Thread.currentThread().setContextClassLoader(cliCl);
+        final Object builder = cliCl.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration$Builder").newInstance();
+        final Method setEchoCommand = builder.getClass().getMethod("setEchoCommand", boolean.class);
+        setEchoCommand.invoke(builder, true);
+        final Method setResolve = builder.getClass().getMethod("setResolveParameterValues", boolean.class);
+        setResolve.invoke(builder, resolveExpression);
+        final Method setOutput = builder.getClass().getMethod("setConsoleOutput", OutputStream.class);
+        setOutput.invoke(builder, out);
+        Object ctxConfig = builder.getClass().getMethod("build").invoke(builder);
+        Object factory = cliCl.loadClass("org.jboss.as.cli.CommandContextFactory").getMethod("getInstance").invoke(null);
+        final Class<?> configClass = cliCl.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration");
+        ctx = factory.getClass().getMethod("newCommandContext", configClass).invoke(factory, ctxConfig);
+        handle = ctx.getClass().getMethod("handle", String.class);
+        terminateSession = ctx.getClass().getMethod("terminateSession");
+        getModelControllerClient = ctx.getClass().getMethod("getModelControllerClient");
+    }
+
+    void handle(String command) throws Exception {
+        handle.invoke(ctx, command);
+    }
+
+    String getOutput() {
+        return out.toString();
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            terminateSession.invoke(ctx);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalCl);
+            try {
+                cliCl.close();
+            } catch (IOException e) {
+            }
+            mojo.enableLog(level);
+            if (origConfig != null) {
+                System.setProperty("jboss.cli.config", origConfig);
+            }
+        }
+    }
+
+    ModelControllerClient getModelControllerClient() throws Exception {
+        return (ModelControllerClient) getModelControllerClient.invoke(ctx);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,13 @@
     <version.org.asciidoctor>2.0.0</version.org.asciidoctor>
     <version.org.jboss.galleon>4.2.5.Final</version.org.jboss.galleon>
     <version.org.wildfly.core.wildfly-core>13.0.0.Beta5</version.org.wildfly.core.wildfly-core>
+    <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.wildfly.plugins.wildfly-maven-plugin>2.0.1.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
     <!-- required by tests -->
     <version.org.apache.httpcomponents.httpclient>4.5.11</version.org.apache.httpcomponents.httpclient>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
     <version.org.jboss.logging.slf4j-jboss-logging>1.1.0.Final</version.org.jboss.logging.slf4j-jboss-logging>
+    <version.org.jboss.logmanager>2.1.17.Final</version.org.jboss.logmanager>
     <version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>3.3.0
     </version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
     <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
@@ -142,6 +144,12 @@
       </dependency>
       
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+          <version>${version.org.wildfly.common}</version>
+      </dependency>
+      
+      <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-api</artifactId>
         <version>${version.org.jboss.shrinkwrap.shrinkwrap}</version>
@@ -182,12 +190,6 @@
         <groupId>org.wildfly.checkstyle</groupId>
         <artifactId>wildfly-checkstyle-config</artifactId>
         <version>${version.org.wildfly.checkstyle-config}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.wildfly.core</groupId>
-        <artifactId>wildfly-cli</artifactId>
-        <version>${version.org.wildfly.core.wildfly-core}</version>
       </dependency>
       
       <dependency>
@@ -237,6 +239,11 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.jboss.logmanager</groupId>
+          <artifactId>jboss-logmanager</artifactId>
+          <version>${version.org.jboss.logmanager}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -92,6 +92,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+          <scope>test</scope>
+      </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-patching</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFWIP-346

The root cause is JBoss modules can't be shared between execution (global ModuleLoader singleton).

* Isolated CLI execution in its own classloader. CLI classes are accessed via reflective calls.
* Removed cli/embedded/patching artifact dependencies. They can't be in the maven plugin classloader.
