### PR TITLE
Remove log manager and wildfly-common dependencies

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -97,10 +97,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.wildfly.common</groupId>
-            <artifactId>wildfly-common</artifactId>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -108,11 +108,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -165,8 +160,7 @@
                                         <exclude>org.wildfly.core:wildfly-cli</exclude>
                                         <exclude>org.wildfly.core:wildfly-embedded</exclude>
                                         <exclude>org.wildfly.core:wildfly-patching</exclude>
-                                        <!-- should be banned but needed by tests -->
-                                        <!--<exclude>org.jboss.logmanager:jboss-logmanager</exclude>-->
+                                        <exclude>org.jboss.logmanager:jboss-logmanager</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/Expression.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/Expression.java
@@ -1,0 +1,235 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jboss.dmr.ValueExpression;
+
+/**
+ * A simple expression parser which only parses the possible keys and default values.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Expression {
+
+    private static final int INITIAL = 0;
+    private static final int GOT_DOLLAR = 1;
+    private static final int GOT_OPEN_BRACE = 2;
+    private static final int RESOLVED = 3;
+    private static final int DEFAULT = 4;
+
+    private final List<String> keys;
+    private final String defaultValue;
+
+    private Expression(final Collection<String> keys, final String defaultValue) {
+        this.keys = new ArrayList<>(keys);
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * Creates a collection of expressions based on the value.
+     *
+     * @param value the expression value
+     *
+     * @return the expression keys and default value for each expression found within the value
+     */
+    static Collection<Expression> parse(final ValueExpression value) {
+        return parseExpression(value.getExpressionString());
+    }
+
+    /**
+     * Creates a collection of expressions based on the value.
+     *
+     * @param value the expression value
+     *
+     * @return the expression keys and default value for each expression found within the value
+     */
+    static Collection<Expression> parse(final String expression) {
+        return parseExpression(expression);
+    }
+
+    /**
+     * All the keys associated with this expression.
+     *
+     * @return the keys
+     */
+    List<String> getKeys() {
+        return Collections.unmodifiableList(keys);
+    }
+
+    /**
+     * Checks if there is a default value.
+     *
+     * @return {@code true} if the default value is not {@code null}, otherwise {@code false}
+     */
+    boolean hasDefault() {
+        return defaultValue != null;
+    }
+
+    /**
+     * Returns the default value which may be {@code null}.
+     *
+     * @return the default value
+     */
+    String getDefaultValue() {
+        return defaultValue;
+    }
+
+    void appendTo(final StringBuilder builder) {
+        builder.append("${");
+        final Iterator<String> iter = keys.iterator();
+        while (iter.hasNext()) {
+            builder.append(iter.next());
+            if (iter.hasNext()) {
+                builder.append(',');
+            }
+        }
+        if (hasDefault()) {
+            builder.append(':').append(defaultValue);
+        }
+        builder.append('}');
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        appendTo(builder);
+        return builder.toString();
+    }
+
+    private static Collection<Expression> parseExpression(final String expression) {
+        final Collection<Expression> result = new ArrayList<>();
+        final Collection<String> keys = new ArrayList<>();
+        final StringBuilder key = new StringBuilder();
+        String defaultValue = null;
+        final char[] chars = expression.toCharArray();
+        final int len = chars.length;
+        int state = 0;
+        int start = -1;
+        int nameStart = -1;
+        for (int i = 0; i < len; i++) {
+            char ch = chars[i];
+            switch (state) {
+                case INITIAL: {
+                    if (ch == '$') {
+                        state = GOT_DOLLAR;
+                    }
+                    continue;
+                }
+                case GOT_DOLLAR: {
+                    if (ch == '{') {
+                        start = i + 1;
+                        nameStart = start;
+                        state = GOT_OPEN_BRACE;
+                    } else {
+                        // invalid; emit and resume
+                        state = INITIAL;
+                    }
+                    continue;
+                }
+                case GOT_OPEN_BRACE: {
+                    switch (ch) {
+                        case ':':
+                        case '}':
+                        case ',': {
+                            final String name = expression.substring(nameStart, i).trim();
+                            if ("/".equals(name)) {
+                                state = ch == '}' ? INITIAL : RESOLVED;
+                                continue;
+                            } else if (":".equals(name)) {
+                                state = ch == '}' ? INITIAL : RESOLVED;
+                                continue;
+                            }
+                            key.append(name);
+                            if (ch == '}') {
+                                state = INITIAL;
+                                if (key.length() > 0) {
+                                    keys.add(key.toString());
+                                    key.setLength(0);
+                                }
+                                result.add(new Expression(keys, defaultValue));
+                                defaultValue = null;
+                                keys.clear();
+                                continue;
+                            } else if (ch == ',') {
+                                if (key.length() > 0) {
+                                    keys.add(key.toString());
+                                    key.setLength(0);
+                                }
+                                nameStart = i + 1;
+                                continue;
+                            } else {
+                                start = i + 1;
+                                state = DEFAULT;
+                                if (key.length() > 0) {
+                                    keys.add(key.toString());
+                                    key.setLength(0);
+                                }
+                                continue;
+                            }
+                        }
+                        default: {
+                            continue;
+                        }
+                    }
+                }
+                case RESOLVED: {
+                    if (ch == '}') {
+                        state = INITIAL;
+                        if (keys.size() > 0) {
+                            result.add(new Expression(keys, defaultValue));
+                            defaultValue = null;
+                            keys.clear();
+                        }
+                    }
+                    continue;
+                }
+                case DEFAULT: {
+                    if (ch == '}') {
+                        state = INITIAL;
+                        defaultValue = expression.substring(start, i);
+                        if (key.length() > 0) {
+                            keys.add(key.toString());
+                            key.setLength(0);
+                        }
+                        if (keys.size() > 0) {
+                            result.add(new Expression(keys, defaultValue));
+                            defaultValue = null;
+                            keys.clear();
+                        }
+                    }
+                    continue;
+                }
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+        if (key.length() > 0) {
+            keys.add(key.toString());
+            result.add(new Expression(keys, defaultValue));
+        }
+        return result;
+    }
+}

--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ExpressionTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ExpressionTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ExpressionTestCase {
+
+    @Test
+    public void testExpressions() {
+        testExpression("${jboss.server.log.dir}/server.log", "jboss.server.log.dir", null);
+        testExpression("${jboss.server.log.dir:C:\\User\\default\\}\\server.log",
+                "jboss.server.log.dir", "C:\\User\\default\\");
+
+        testExpression("${test.level:DEBUG}", "test.level", "DEBUG");
+
+        testExpression("${test$$.no-default}", "test$$.no-default", null);
+
+        testExpression("${key1,key2,key3}", Arrays.asList("key1", "key2", "key3"), null);
+        testExpression("${key1,key2,key3:defaultValue}", Arrays.asList("key1", "key2", "key3"), "defaultValue");
+
+        String toTest = "${test.log.dir,jboss.server.log.dir:/var/log}/${test.path}/test.log";
+        Map<Collection<String>, String> expectedResults = new LinkedHashMap<>();
+        expectedResults.put(Arrays.asList("test.log.dir", "jboss.server.log.dir"), "/var/log");
+        expectedResults.put(Collections.singletonList("test.path"), null);
+        testExpression(toTest, expectedResults);
+    }
+
+    private void testExpression(final String toTest, final String expectedKey, final String expectedDefaultValue) {
+        testExpression(toTest, Collections.singletonMap(Collections.singletonList(expectedKey), expectedDefaultValue));
+    }
+
+    private void testExpression(final String toTest, final Collection<String> expectedKeys, final String expectedDefaultValue) {
+        testExpression(toTest, Collections.singletonMap(expectedKeys, expectedDefaultValue));
+    }
+
+    private void testExpression(final String toTest, final Map<Collection<String>, String> expected) {
+        final Collection<Expression> expressions = Expression.parse(toTest);
+        if (expected.size() != expressions.size()) {
+            final String msg = String.format("Found results don't match the expected results.%nPattern: %s%nFound: %s%nExpected: %s%n",
+                    toTest, expressions, expected);
+            Assert.fail(msg);
+
+        }
+        final Iterator<Map.Entry<Collection<String>, String>> iter = expected.entrySet().iterator();
+        for (Expression expression : expressions) {
+            final Map.Entry<Collection<String>, String> entry = iter.next();
+            Assert.assertEquals(entry.getKey(), expression.getKeys());
+            Assert.assertEquals(entry.getValue(), expression.getDefaultValue());
+        }
+    }
+}

--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/TestFilter.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/TestFilter.java
@@ -22,8 +22,6 @@ package org.wildfly.plugins.bootablejar.maven.goals;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 
-import org.jboss.logmanager.ExtLogRecord;
-
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
@@ -53,7 +51,7 @@ public class TestFilter implements Filter {
     @Override
     public boolean isLoggable(final LogRecord record) {
         if (isLoggable) {
-            final StringBuilder newMsg = new StringBuilder(ExtLogRecord.wrap(record).getFormattedMessage());
+            final StringBuilder newMsg = new StringBuilder(record.getMessage());
             if (constructorText != null) {
                 newMsg.append(constructorText);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -147,13 +147,15 @@
         <artifactId>wildfly-patching</artifactId>
         <version>${version.org.wildfly.core.wildfly-core}</version>
       </dependency>
-      
+
+      <!-- Required by controller-client which is used in tests -->
       <dependency>
           <groupId>org.wildfly.common</groupId>
           <artifactId>wildfly-common</artifactId>
           <version>${version.org.wildfly.common}</version>
+          <scope>test</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <version.org.apache.httpcomponents.httpclient>4.5.11</version.org.apache.httpcomponents.httpclient>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
     <version.org.jboss.logging.slf4j-jboss-logging>1.1.0.Final</version.org.jboss.logging.slf4j-jboss-logging>
-    <version.org.jboss.logmanager>2.1.17.Final</version.org.jboss.logmanager>
     <version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>3.3.0
     </version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
     <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
@@ -245,11 +244,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.jboss.logmanager</groupId>
-          <artifactId>jboss-logmanager</artifactId>
-          <version>${version.org.jboss.logmanager}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -91,11 +91,12 @@
             <artifactId>slf4j-jboss-logging</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Required by controller-client which is used in tests -->
         <dependency>
-          <groupId>org.wildfly.common</groupId>
-          <artifactId>wildfly-common</artifactId>
-          <scope>test</scope>
-      </dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-patching</artifactId>


### PR DESCRIPTION
Resolves #79 
Resolves #80 

Note that wildfly-common is still required as a transitive dependency for the `controller-client`. However there is no longer a direct dependency on the plugin to it.

This also fixes an issue where a property key maybe be multiple keys e.g. `${key1,key2,key3:default}`