### PR TITLE
Add bootable-jar-build-artifacts property instead of using fixed path name

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
@@ -285,6 +285,16 @@ class AbstractBuildBootableJarMojo extends AbstractMojo {
     @Parameter(alias = "boot-logging-config", property = "wildfly.bootable.logging.config")
     private File bootLoggingConfig;
 
+    /**
+     * By default, when building a bootable jar, the plugin extracts build artifacts in the directory
+     * 'bootable-jar-build-artifacts'. You can use this property to change this directory name. In most cases
+     * this should not be required. The use-case is when building multiple bootable JARs in the same project
+     * on Windows Platform. In this case, each execution should have its own directory, the plugin being
+     * unable to delete the directory due to some references to JBoss module files.
+     */
+    @Parameter(alias = "bootable-jar-build-artifacts", property = "wildfly.bootable.jar.build.artifacts", defaultValue = "bootable-jar-build-artifacts")
+    private String bootableJarBuildArtifacts;
+
     @Inject
     private BootLoggingConfiguration bootLoggingConfiguration;
 
@@ -324,7 +334,7 @@ class AbstractBuildBootableJarMojo extends AbstractMojo {
             }
             return;
         }
-        Path contentRoot = Paths.get(project.getBuild().getDirectory()).resolve("bootable-jar-build-artifacts");
+        Path contentRoot = Paths.get(project.getBuild().getDirectory()).resolve(bootableJarBuildArtifacts);
         if (Files.exists(contentRoot)) {
             deleteDir(contentRoot);
         }

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevServerTestCase.java
@@ -41,7 +41,7 @@ public class DevServerTestCase extends AbstractBootableJarMojoTestCase {
         mojo.execute();
         final Path dir = getTestDir();
         checkJar(dir, false, false, null, null, "target" + File.separator + "deployments");
-        Path config = dir.resolve("target").resolve("bootable-jar-build-artifacts").
+        Path config = dir.resolve("target").resolve("build-artifacts").
                 resolve("wildfly").resolve("standalone").resolve("configuration").resolve("standalone.xml");
         assertTrue(Files.exists(config));
         String content = new String(Files.readAllBytes(config), StandardCharsets.UTF_8);

--- a/tests/src/test/resources/poms/test6-pom.xml
+++ b/tests/src/test/resources/poms/test6-pom.xml
@@ -25,6 +25,7 @@
                         <!-- force exclusion, dev mode must re-include it -->
                         <layer>deployment-scanner</layer>
                     </excluded-layers>
+                    <bootableJarBuildArtifacts>build-artifacts</bootableJarBuildArtifacts>
                 </configuration>
                 
             </plugin>


### PR DESCRIPTION
This way it is possible to run plugin multiple times to produce more then one jar during module build.

On Windows there is a problem where after shutting down wildfly in a JVM some module JAR files are left open and can't be removed/overridden before JVM exits. Because of that every try to use the plugin during the same module build to produce another jar fails.

Using that property it is possible to use different directory for the next plugin use. 

You can check this project for more details:
https://github.com/doychin/wildfly-bootable-jar-arquillian-example

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>