### PR TITLE
Fix wildfly-common dependency required my plugin

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -97,7 +97,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <!-- Required by Galleon during provisioning --> 
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,12 +148,11 @@
         <version>${version.org.wildfly.core.wildfly-core}</version>
       </dependency>
 
-      <!-- Required by controller-client which is used in tests -->
+      <!-- Required by controller-client and Galleon provisioning -->
       <dependency>
           <groupId>org.wildfly.common</groupId>
           <artifactId>wildfly-common</artifactId>
           <version>${version.org.wildfly.common}</version>
-          <scope>test</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This has been introduced by https://github.com/wildfly-extras/wildfly-jar-maven-plugin/pull/81,
the dependency in the tests was hiding the required dependency outside tests.