### PR TITLE
Remove test-config dir before running the test. If not removed the following copy operation fails.

### DIFF
--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootLoggingConfigurationTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootLoggingConfigurationTestCase.java
@@ -102,9 +102,9 @@ public class BootLoggingConfigurationTestCase {
     @Before
     public void setup() throws Exception {
         tmpDir = TestEnvironment.createTempPath("test-config", testName.getMethodName());
-        if (Files.notExists(tmpDir)) {
-            Files.createDirectories(tmpDir);
-        }
+        AbstractBuildBootableJarMojo.deleteDir(tmpDir);
+        Files.createDirectories(tmpDir);
+
         // TODO (jrp) The reload and wait can be removed once https://issues.redhat.com/browse/WFCORE-5113 is resolved
         executeOperation(Operations.createOperation("reload"));
         ServerHelper.waitForStandalone(currentProcess, client, TestEnvironment.getTimeout());


### PR DESCRIPTION
When you run

mvn clean verify 

everything works as expected but after that if you just run

mvn verify 

build fails because there are files in test-config directory. When test prepares to run it fails because of that. 

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>