### PR TITLE
galleon plugin must be added to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
         <version>${project.version}</version>
       </plugin>
       
+      <plugin>
+          <groupId>org.jboss.galleon</groupId>
+          <artifactId>galleon-maven-plugin</artifactId>
+          <version>${version.org.jboss.galleon}</version>
+      </plugin>
+
         <!-- Checkstyle -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
galleon-plugin version is not properly handled. The version must be explicitly set for galleon plugin execution.