### PR TITLE
Fix for WFWIP-349, Maven reports OOM on JDK 1.8 when packaging multiple applications

### DIFF
--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -1,0 +1,5 @@
+## WildFly bootable jar perf tests
+
+In order to enable test execution set -Dskip.perf.tests=false
+
+* plugin-memory: Run mutliple executions of the plugin the same JVM. 

--- a/perf-tests/plugin-memory/pom.xml
+++ b/perf-tests/plugin-memory/pom.xml
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2020 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-maven-plugin-perf-tests-parent</artifactId>
+        <version>2.0.0.Beta6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jar-maven-plugin-memory-tests</artifactId>
+    <packaging>pom</packaging>
+
+    <name>WildFly Bootable Jar Maven Plugin memory consumption tests</name>
+
+    <build>
+        <plugins>
+            <!-- provision a full server to be used as patching distribution source -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <plugin-options>
+                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                    </plugin-options>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>${wildfly.groupId}</groupId>
+                            <artifactId>${wildfly.artifactId}</artifactId>
+                            <version>${version.wildfly}</version>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>jaxrs-server</layer>
+                    </layers>
+                    <hollowJar>true</hollowJar>
+                    <cloud/>
+                    <skip>${skip.perf.tests}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bootable JAR 1</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest1.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest1</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 2</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest2.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest2</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 3</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest3.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest3</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 4</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest4.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest4</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 5</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest5.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest5</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 6</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest6.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest6</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 7</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest7.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest7</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 8</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest8.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest8</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 9</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest9.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest9</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 10</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest10.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest10</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 11</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest11.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest11</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 12</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest12.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest12</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 13</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest13.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest13</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 14</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest14.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest14</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 15</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest15.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest15</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 16</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest16.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest16</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 17</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest17.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest17</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 18</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest18.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest18</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 19</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest19.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest19</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 20</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest20.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest20</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 21</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest21.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest21</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 22</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest22.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest22</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 23</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest23.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest23</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 24</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest24.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest24</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 25</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest25.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest25</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 26</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest26.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest26</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 27</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest27.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest27</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 28</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest28.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest28</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 29</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest29.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest29</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable JAR 30</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <outputFileName>perftest30.jar</outputFileName>
+                            <bootableJarBuildArtifacts>perftest30</bootableJarBuildArtifacts>
+                        </configuration>
+                    </execution>
+                    
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/perf-tests/pom.xml
+++ b/perf-tests/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2020 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-parent</artifactId>
+        <version>2.0.0.Beta6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jar-maven-plugin-perf-tests-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>WildFly Bootable Jar Maven Plugin perf tests parent</name>
+
+    <properties>
+        <skip.perf.tests>true</skip.perf.tests>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-jar-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-jar-cloud-extension</artifactId>
+        </dependency>
+    </dependencies>
+    <modules>
+        <module>plugin-memory</module>
+    </modules>
+</project>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+import java.util.List;
+
+/**
+ * @author jdenise
+ */
+public interface CLIExecutor extends AutoCloseable {
+
+
+    void handle(String command) throws Exception;
+
+    String getOutput() throws Exception;
+
+    void generateBootLoggingConfig() throws Exception;
+
+    void execute(List<String> commands) throws Exception;
+}

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIForkedBootConfigGenerator.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIForkedBootConfigGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import org.wildfly.plugins.bootablejar.maven.goals.BootLoggingConfiguration;
+
+/**
+ * Generate boot logging config forked process entry point.
+ *
+ * @author jdenise
+ */
+public class CLIForkedBootConfigGenerator {
+
+    public static void main(String[] args) throws Exception {
+        Path jbossHome = Paths.get(args[0]);
+        Path cliOutput = Paths.get(args[1]);
+        Path systemProperties = Paths.get(args[2]);
+        Properties properties = new Properties();
+        try (FileInputStream in = new FileInputStream(systemProperties.toFile())) {
+            properties.load(in);
+            for (String key : properties.stringPropertyNames()) {
+                System.setProperty(key, properties.getProperty(key));
+            }
+        }
+        try (CLIWrapper executor = new CLIWrapper(jbossHome, false, CLIForkedBootConfigGenerator.class.getClassLoader(), new BootLoggingConfiguration())) {
+            try {
+                executor.generateBootLoggingConfig();
+            } finally {
+                Files.write(cliOutput, executor.getOutput().getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIForkedExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIForkedExecutor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * Execute CLI in forked process entry point.
+ *
+ * @author jdenise
+ */
+public class CLIForkedExecutor {
+
+    public static void main(String[] args) throws Exception {
+        Path jbossHome = Paths.get(args[0]);
+        Path cliOutput = Paths.get(args[1]);
+        Path systemProperties = Paths.get(args[2]);
+        Path script = Paths.get(args[3]);
+        Boolean resolveExpression = Boolean.parseBoolean(args[4]);
+        Properties properties = new Properties();
+        try (FileInputStream in = new FileInputStream(systemProperties.toFile())) {
+            properties.load(in);
+            for (String key : properties.stringPropertyNames()) {
+                System.setProperty(key, properties.getProperty(key));
+            }
+        }
+        try (CLIWrapper executor = new CLIWrapper(jbossHome, resolveExpression, CLIForkedExecutor.class.getClassLoader())) {
+            try {
+                for (String command : Files.readAllLines(script)) {
+                    executor.handle(command);
+                }
+            } finally {
+                Files.write(cliOutput, executor.getOutput().getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIWrapper.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/CLIWrapper.java
@@ -14,51 +14,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.plugins.bootablejar.maven.goals;
+package org.wildfly.plugins.bootablejar.maven.cli;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.logging.Level;
-import org.apache.maven.artifact.Artifact;
+import java.util.Objects;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.wildfly.plugins.bootablejar.maven.goals.BootLoggingConfiguration;
 
 /**
- * A CLI executor, resolving CLI classes from an URL Classloader. We can't have
- * cli/embedded/jboss modules in plugin classpath, it causes issue because we
- * are sharing the same jboss module classes between execution run inside the
+ * A CLI executor, resolving CLI classes from the provided Classloader. We can't
+ * have cli/embedded/jboss modules in plugin classpath, it causes issue because
+ * we are sharing the same jboss module classes between execution run inside the
  * same JVM.
  *
  * CLI dependencies are retrieved from provisioned server artifacts list and
  * resolved using maven. In addition jboss-modules.jar located in the
- * provisioned server * is added.
+ * provisioned server is added.
  *
  * @author jdenise
  */
-class CLIExecutor implements AutoCloseable {
+public class CLIWrapper implements AutoCloseable {
 
-    private final Level level;
     private final Object ctx;
     private final Method handle;
     private final Method terminateSession;
     private final Method getModelControllerClient;
-    private final ClassLoader originalCl;
-    private final URLClassLoader cliCl;
-    private final String origConfig;
-    private final AbstractBuildBootableJarMojo mojo;
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final String origConfig;
+    private final Path jbossHome;
+    private final BootLoggingConfiguration bootLoggingConfiguration;
 
-    CLIExecutor(Path jbossHome, Set<Artifact> cliArtifacts,
-            AbstractBuildBootableJarMojo mojo, boolean resolveExpression) throws Exception {
-        this.mojo = mojo;
-        level = mojo.disableLog();
+    public CLIWrapper(Path jbossHome, boolean resolveExpression, ClassLoader loader) throws Exception {
+        this(jbossHome, resolveExpression, loader, null);
+    }
+
+    public CLIWrapper(Path jbossHome, boolean resolveExpression, ClassLoader loader, BootLoggingConfiguration bootLoggingConfiguration) throws Exception {
+        this.jbossHome = jbossHome;
         Path config = jbossHome.resolve("bin").resolve("jboss-cli.xml");
         origConfig = System.getProperty("jboss.cli.config");
         if (Files.exists(config)) {
@@ -66,19 +61,7 @@ class CLIExecutor implements AutoCloseable {
         }
 
 
-        final URL[] cp = new URL[cliArtifacts.size() + 1];
-        cp[0] = jbossHome.resolve("jboss-modules.jar").toUri().toURL();
-        mojo.getLog().debug("CLI artifacts " + cliArtifacts);
-        Iterator<Artifact> it = cliArtifacts.iterator();
-        int i = 1;
-        while (it.hasNext()) {
-            cp[i] = mojo.resolveArtifact(it.next()).toUri().toURL();
-            i += 1;
-        }
-        originalCl = Thread.currentThread().getContextClassLoader();
-        cliCl = new URLClassLoader(cp, originalCl);
-        Thread.currentThread().setContextClassLoader(cliCl);
-        final Object builder = cliCl.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration$Builder").newInstance();
+        final Object builder = loader.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration$Builder").newInstance();
         final Method setEchoCommand = builder.getClass().getMethod("setEchoCommand", boolean.class);
         setEchoCommand.invoke(builder, true);
         final Method setResolve = builder.getClass().getMethod("setResolveParameterValues", boolean.class);
@@ -86,19 +69,20 @@ class CLIExecutor implements AutoCloseable {
         final Method setOutput = builder.getClass().getMethod("setConsoleOutput", OutputStream.class);
         setOutput.invoke(builder, out);
         Object ctxConfig = builder.getClass().getMethod("build").invoke(builder);
-        Object factory = cliCl.loadClass("org.jboss.as.cli.CommandContextFactory").getMethod("getInstance").invoke(null);
-        final Class<?> configClass = cliCl.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration");
+        Object factory = loader.loadClass("org.jboss.as.cli.CommandContextFactory").getMethod("getInstance").invoke(null);
+        final Class<?> configClass = loader.loadClass("org.jboss.as.cli.impl.CommandContextConfiguration");
         ctx = factory.getClass().getMethod("newCommandContext", configClass).invoke(factory, ctxConfig);
         handle = ctx.getClass().getMethod("handle", String.class);
         terminateSession = ctx.getClass().getMethod("terminateSession");
         getModelControllerClient = ctx.getClass().getMethod("getModelControllerClient");
+        this.bootLoggingConfiguration = bootLoggingConfiguration;
     }
 
-    void handle(String command) throws Exception {
+    public void handle(String command) throws Exception {
         handle.invoke(ctx, command);
     }
 
-    String getOutput() {
+    public String getOutput() {
         return out.toString();
     }
 
@@ -107,19 +91,43 @@ class CLIExecutor implements AutoCloseable {
         try {
             terminateSession.invoke(ctx);
         } finally {
-            Thread.currentThread().setContextClassLoader(originalCl);
-            try {
-                cliCl.close();
-            } catch (IOException e) {
-            }
-            mojo.enableLog(level);
             if (origConfig != null) {
                 System.setProperty("jboss.cli.config", origConfig);
             }
         }
     }
 
-    ModelControllerClient getModelControllerClient() throws Exception {
+    private ModelControllerClient getModelControllerClient() throws Exception {
         return (ModelControllerClient) getModelControllerClient.invoke(ctx);
+    }
+
+    public void generateBootLoggingConfig() throws Exception {
+        Objects.requireNonNull(bootLoggingConfiguration);
+        Exception toThrow = null;
+        try {
+            // Start the embedded server
+            handle("embed-server --jboss-home=" + jbossHome + " --std-out=discard");
+            // Get the client used to execute the management operations
+            final ModelControllerClient client = getModelControllerClient();
+            // Update the bootable logging config
+            final Path configDir = jbossHome.resolve("standalone").resolve("configuration");
+            bootLoggingConfiguration.generate(configDir, client);
+        } catch (Exception e) {
+            toThrow = e;
+        } finally {
+            try {
+                // Always stop the embedded server
+                handle("stop-embedded-server");
+            } catch (Exception e) {
+                if (toThrow != null) {
+                    e.addSuppressed(toThrow);
+                }
+                toThrow = e;
+            }
+        }
+        // Check if an error has been thrown and throw it.
+        if (toThrow != null) {
+            throw toThrow;
+        }
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/ForkedCLIUtil.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/ForkedCLIUtil.java
@@ -1,0 +1,143 @@
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.logging.Log;
+import org.jboss.galleon.Errors;
+
+import org.jboss.galleon.ProvisioningException;
+
+
+/**
+ *
+ * @author jdenise
+ */
+public class ForkedCLIUtil {
+
+    private static String javaHome;
+    private static String javaCmd;
+
+    private static String getJavaHome() {
+        return javaHome == null ? javaHome = System.getProperty("java.home") : javaHome;
+    }
+
+    private static String getJavaCmd() {
+        return javaCmd == null ? javaCmd = Paths.get(getJavaHome()).resolve("bin").resolve("java").toString() : javaCmd;
+    }
+
+    public static void fork(Log log, String[] artifacts, Class<?> clazz, Path home, Path output, String... args) throws Exception {
+        // prepare the classpath
+        final StringBuilder cp = new StringBuilder();
+        for (String loc : artifacts) {
+            cp.append(loc).append(File.pathSeparator);
+        }
+        collectCpUrls(getJavaHome(), Thread.currentThread().getContextClassLoader(), cp);
+
+        Path properties = storeSystemProps();
+
+        final List<String> argsList = new ArrayList<>();
+        argsList.add(getJavaCmd());
+        argsList.add("-server");
+        argsList.add("-cp");
+        argsList.add(cp.toString());
+        argsList.add(clazz.getName());
+        argsList.add(home.toString());
+        argsList.add(output.toString());
+        argsList.add(properties.toString());
+        for (String s : args) {
+            argsList.add(s);
+        }
+
+        try {
+            final Process p;
+            try {
+                p = new ProcessBuilder(argsList).redirectErrorStream(true).start();
+            } catch (IOException e) {
+                throw new ProvisioningException("Failed to start forked process", e);
+            }
+            StringBuilder traces = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                String line = reader.readLine();
+                while (line != null) {
+                    traces.append(line).append(System.lineSeparator());
+                    line = reader.readLine();
+                }
+                if (p.isAlive()) {
+                    try {
+                        p.waitFor();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            int exitCode = p.exitValue();
+            if (exitCode != 0) {
+                log.error("Error executing CLI:" + traces);
+                throw new Exception("CLI execution failed.");
+            }
+        } finally {
+            Files.deleteIfExists(properties);
+        }
+    }
+
+    private static Path storeSystemProps() throws ProvisioningException {
+        final Path props;
+        try {
+            props = Files.createTempFile("wfbootablejar", "sysprops");
+        } catch (IOException e) {
+            throw new ProvisioningException("Failed to create a tmp file", e);
+        }
+        try (BufferedWriter writer = Files.newBufferedWriter(props)) {
+            System.getProperties().store(writer, "");
+        } catch (IOException e) {
+            throw new ProvisioningException(Errors.writeFile(props), e);
+        }
+        return props;
+    }
+
+    private static void collectCpUrls(String javaHome, ClassLoader cl, StringBuilder buf) {
+        final ClassLoader parentCl = cl.getParent();
+        if(parentCl != null) {
+            collectCpUrls(javaHome, cl.getParent(), buf);
+        }
+        if (cl instanceof URLClassLoader) {
+            for (URL url : ((URLClassLoader)cl).getURLs()) {
+                final String file = url.getFile();
+                if(file.startsWith(javaHome)) {
+                    continue;
+                }
+                if (buf.length() > 0) {
+                    buf.append(File.pathSeparatorChar);
+                }
+                buf.append(file);
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/LocalCLIExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/LocalCLIExecutor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import org.wildfly.plugins.bootablejar.maven.goals.AbstractBuildBootableJarMojo;
+import org.wildfly.plugins.bootablejar.maven.goals.BootLoggingConfiguration;
+
+/**
+ * A CLI executor, resolving CLI classes from an URL Classloader. We can't have
+ * cli/embedded/jboss modules in plugin classpath, it causes issue because we
+ * are sharing the same jboss module classes between execution run inside the
+ * same JVM.
+ *
+ * CLI dependencies are retrieved from provisioned server artifacts list and
+ * resolved using maven. In addition jboss-modules.jar located in the
+ * provisioned server * is added.
+ *
+ * @author jdenise
+ */
+public class LocalCLIExecutor implements CLIExecutor {
+
+    private final Level level;
+    private final ClassLoader originalCl;
+    private final URLClassLoader cliCl;
+    private final AbstractBuildBootableJarMojo mojo;
+    private final CLIWrapper cliWrapper;
+
+    public LocalCLIExecutor(Path jbossHome, List<Path> cliArtifacts,
+            AbstractBuildBootableJarMojo mojo, boolean resolveExpression, BootLoggingConfiguration bootLoggingConfiguration) throws Exception {
+        this.mojo = mojo;
+        level = mojo.disableLog();
+        final URL[] cp = new URL[cliArtifacts.size()];
+        Iterator<Path> it = cliArtifacts.iterator();
+        int i = 0;
+        while (it.hasNext()) {
+            cp[i] = it.next().toUri().toURL();
+            i += 1;
+        }
+        originalCl = Thread.currentThread().getContextClassLoader();
+        cliCl = new URLClassLoader(cp, originalCl);
+        Thread.currentThread().setContextClassLoader(cliCl);
+        cliWrapper = new CLIWrapper(jbossHome, resolveExpression, cliCl, bootLoggingConfiguration);
+    }
+
+    @Override
+    public void handle(String command) throws Exception {
+        cliWrapper.handle(command);
+    }
+
+    @Override
+    public String getOutput() {
+        return cliWrapper.getOutput();
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            cliWrapper.close();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalCl);
+            try {
+                cliCl.close();
+            } catch (IOException e) {
+            }
+            mojo.enableLog(level);
+        }
+    }
+
+    @Override
+    public void execute(List<String> commands) throws Exception {
+        for (String cmd : commands) {
+            handle(cmd);
+        }
+    }
+
+    @Override
+    public void generateBootLoggingConfig() throws Exception {
+        cliWrapper.generateBootLoggingConfig();
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/RemoteCLIExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cli/RemoteCLIExecutor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.cli;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Level;
+import org.wildfly.plugins.bootablejar.maven.goals.AbstractBuildBootableJarMojo;
+
+/**
+ * A CLI executor, that forks CLI execution in a remote process.
+ *
+ * @author jdenise
+ */
+public class RemoteCLIExecutor implements CLIExecutor {
+
+    private final Level level;
+    private final AbstractBuildBootableJarMojo mojo;
+    private final Path output;
+    private final Path jbossHome;
+    private final String[] cp;
+    private final boolean resolveExpression;
+
+    public RemoteCLIExecutor(Path jbossHome, List<Path> cliArtifacts,
+            AbstractBuildBootableJarMojo mojo, boolean resolveExpression) throws Exception {
+        this.jbossHome = jbossHome;
+        this.mojo = mojo;
+        this.resolveExpression = resolveExpression;
+        level = mojo.disableLog();
+        output = File.createTempFile("cli-script-output", null).toPath();
+        Files.deleteIfExists(output);
+        cp = new String[cliArtifacts.size()];
+        int i = 0;
+        for (Path p : cliArtifacts) {
+            cp[i] = p.toString();
+            i += 1;
+        }
+    }
+
+    @Override
+    public void handle(String command) throws Exception {
+        throw new UnsupportedOperationException("handle is unsupported, call execute instead.");
+    }
+
+    @Override
+    public String getOutput() throws Exception {
+        StringBuilder out = new StringBuilder();
+        for (String s : Files.readAllLines(output)) {
+            out.append(s).append("\n");
+        }
+        return out.toString();
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            Files.deleteIfExists(output);
+        } finally {
+            mojo.enableLog(level);
+        }
+    }
+
+    @Override
+    public void execute(List<String> commands) throws Exception {
+        Path script = File.createTempFile("cli-script", null).toPath();
+        Files.deleteIfExists(script);
+        Files.deleteIfExists(output);
+        StringBuilder cmds = new StringBuilder();
+        for (String cmd : commands) {
+            cmds.append(cmd).append(System.lineSeparator());
+        }
+        Files.write(script, cmds.toString().getBytes(StandardCharsets.UTF_8));
+        String[] args = new String[2];
+        args[0] = script.toString();
+        args[1] = Boolean.toString(resolveExpression);
+        try {
+            ForkedCLIUtil.fork(mojo.getLog(), cp, CLIForkedExecutor.class, jbossHome, output, args);
+        } finally {
+            Files.deleteIfExists(script);
+        }
+    }
+
+    @Override
+    public void generateBootLoggingConfig() throws Exception {
+        ForkedCLIUtil.fork(mojo.getLog(), cp, CLIForkedBootConfigGenerator.class, jbossHome, output);
+    }
+}

--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootLoggingConfigurationTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/BootLoggingConfigurationTestCase.java
@@ -674,7 +674,8 @@ public class BootLoggingConfigurationTestCase {
 
     private void generateAndTest(final Properties expectedBootConfig, final boolean ignoreGeneratedFormatters) throws Exception {
         final BootLoggingConfiguration config = new BootLoggingConfiguration();
-        config.enableLogging(TestLogger.getLogger(BootLoggingConfigurationTestCase.class));
+        // @TODO, we can't use AbstractLogEnabled, it is not in the maven plugin classloader.
+        //config.enableLogging(TestLogger.getLogger(BootLoggingConfigurationTestCase.class));
         config.generate(tmpDir, client);
         compare(load(findLoggingConfig(), true, true),
                 load(tmpDir.resolve("logging.properties"), false, true), true, ignoreGeneratedFormatters);

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <module>plugin</module>
     <module>tests</module>
     <module>extensions</module>
+    <module>perf-tests</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFWIP-349

In order for large execution (20+ plugin executions in the same JVM), we need to fork all CLI executions (some JBoss Modules classes kept in memory due to static references). We are forking only when jboss-fork-embedded=true.
I added a perf test that is disabled by default that passed on CI with 30 executions, no leak in Metaspace.

@jamezp , I had to fork the Boot logging generation in its own process too.



