### PR TITLE
Doc and examples updates for better release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## WildFly bootable jar maven plugin
+## WildFly bootable JAR Maven plugin
 
-This project defines a maven plugin to build bootable jars for WildFly (starting version 20.0.0.Final). 
-A WildFly bootable jar contains both the server and your packaged application (a jar, a ear or a war).
-Once the application has been built and packaged as a bootable jar, you can start the application using the following command:
+This project defines a Maven plugin to build WildFly bootable JAR (starting version 20.0.0.Final). 
+A WildFly bootable JAR contains both the server and your packaged application (a JAR, an EAR or a WAR).
+Once the application has been built and packaged as a bootable JAR, you can start the application using the following command:
 
 ```
 java -jar target/myapp-bootable.jar
@@ -14,31 +14,37 @@ To get the list of the startup arguments:
 java -jar target/myapp-bootable.jar --help
 ```
 
-A WildFly bootable jar behave in a way that is similar to a WildFly server installed on file system:
+A WildFly bootable JAR behave in a way that is similar to a WildFly server installed on file system:
 
 * It supports the main standalone server startup arguments. 
-* It can be administered/monitored using JBoss CLI.
+* It can be administered/monitored using WildFly CLI.
 
 Some limitations exist:
 
-* The server can't be re-started automatically during a shutdown. The bootable jar process will exit without restarting.
-* Management model changes (eg: using JBoss CLI) are not persisted. Once the server is killed, management updates are lost.
+* The server can't be re-started automatically during a shutdown. The bootable JAR process will exit without restarting.
+* Management model changes (eg: using WildFly CLI) are not persisted. Once the server is killed, management updates are lost.
 * Server can't be started in admin mode.
 
-NB: When started, the bootable jar installs a WildFly server in the _TEMP_ directory. The bootable jar displayed traces contain the actual path to this transient installation. This 
-installation is deleted when the bootable jar process exits.
+NB: When started, the bootable JAR installs a WildFly server in the _TEMP_ directory. The bootable JAR displayed traces contain the actual path to this transient installation. This 
+installation is deleted when the bootable JAR process exits.
 
 ## Examples
 
-The directory [examples](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples)
-contains maven example projects that highlight various usages of the WildFly bootable jar. Build and run these projects
-to familiarize yourself with the maven plugin. A good example to start with is the 
+The [examples](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples) directory 
+contains Maven example projects that highlight various usages of the WildFly bootable JAR. Build and run these projects
+to familiarize yourself with the Maven plugin. A good example to start with is the 
 [jaxrs](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jaxrs) example.
 
-Some of these examples are targeting deployment of the bootable jar in OpenShift. 
-For example: [microprofile-config](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/microprofile-config) and 
-[postgresql](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/postgresql).
+Some examples are targeting OpenShift deployment, for example:
 
-Deployment inside a [JIB](https://github.com/GoogleContainerTools/jib) container is 
-covered by [jib](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jib) example and _examples/jib-*_ projects.
+* The [jkube](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jkube) example shows how to make use of the [Eclipse JKube](https://www.eclipse.org/jkube/) Maven plugin.
 
+* The [microprofile-config](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/microprofile-config) and 
+[postgresql](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/postgresql) examples show how to use the OpenShift 'oc' command to deploy a bootable JAR on OpenShift.
+
+* [jib](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jib) example shows how to deploy a bootable JAR inside a [JIB](https://github.com/GoogleContainerTools/jib) container.
+
+## Building the project
+
+* Clone this repository project.
+* Call: `mvn clean install -DskipTests`

--- a/docs/guide/index.adoc
+++ b/docs/guide/index.adoc
@@ -1,4 +1,4 @@
-= WildFly Bootable Jar Documentation
+= WildFly Bootable JAR Documentation
 Jean-Francois Denise
 :revnumber: {version}
 :revdate: {localdate}
@@ -7,6 +7,8 @@ Jean-Francois Denise
 :imagesdir: images
 :linkattrs:
 :sectnums:
+:sectanchors:
+:sectlinks:
 
 :ec2-pub-ip-dash: 1-2-3-4
 :ec2-pub-ip: 1.2.3.4

--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -306,6 +306,11 @@ The WildFly OpenShift Operator can be used to manage deployments based on image 
 At boot time, the WildFly bootable JAR dumps in the file ```/opt/jboss/container/wildfly-bootable-jar/install-dir``` its installation path.
 This information is required by the WildFly OpenShift Operator to retrieve transaction logs and call into WildFly CLI.
 
+IMPORTANT: When deploying WildFly bootable JAR using openjdk image it is strongly advised to set 
+           ```GC_MAX_METASPACE_SIZE=256``` and ```GC_METASPACE_SIZE=96```environment variables.
+           
+
+
 [[wildfly_jar_configuring_runtime]]
 ## Configuring the server at runtime
 
@@ -376,6 +381,20 @@ When using 'dev', 'run' or 'start' goals you can set the _jvmArguments_ configur
 </configuration>
 ----
 
+[[wildfly_jar_enabling_debug_openshift]]
+### Enable Debug for Openshift
+
+You must set the following env variables to enable debug:
+
+* JAVA_DEBUG=true
+* JAVA_DEBUG_PORT=8787
+
+Then enable port forwarding:
+
+* oc get pods
+* oc port-forward <pod name> 8787:8787
+
+Finally, you can attach your debugger to 127.0.0.1:8787
 
 [[wildfly_jar_advanced]]
 ## Advanced usages

--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -1,3 +1,4 @@
+[[wildfly_jar_introduction]]
 ## Introduction
 
 The WildFly JAR Maven plugin is aimed to build a bootable JAR for WildFly (starting version 20.0.0.Final). 
@@ -29,36 +30,50 @@ Some limitations exist:
 NB: When started, the bootable JAR installs a WildFly server in the _TEMP_ directory. 
 The bootable JAR displayed traces contain the actual path to this transient installation. This installation is deleted when the bootable JAR process exits.
 
+[[wildfly_jar_examples]]
 ## Examples
 
-The examples https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples[directory] 
+The examples https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples[directory] 
 contains Maven example projects that highlight various usages of the WildFly bootable JAR. Build and run these projects
 to familiarize yourself with the Maven plugin. A good example to start with is the 
-https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jaxrs[jaxrs] example.
+https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/jaxrs[jaxrs] example.
 
 Some of these examples are targeting deployment of the bootable JAR in OpenShift. 
-For example: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/microprofile-config[microprofile-config], 
-https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/postgresql[postgresql] and 
-https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jkube[jkube].
+For example: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/microprofile-config[microprofile-config], 
+https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/postgresql[postgresql] and 
+https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/jkube[jkube].
 
 Deployment inside a https://github.com/GoogleContainerTools/jib[JIB] container is 
-covered by https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jib[jib] example and _examples/jib-*_ projects.
+covered by https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/jib[jib] example and _examples/jib-*_ projects.
 
+[[wildfly_jar_examples_download]]
+### Downloading the examples
+
+* Clone the wildfly-jar-maven-plugin repository: _git clone -b {project-branch} https://github.com/wildfly-extras/wildfly-jar-maven-plugin_
+
+* _cd wildfly-jar-maven-plugin/examples_
+
+* Each example directory contains a README file with instructions on how to build and run the example.
+
+
+[[wildfly_jar_composing_custom_server_galleon]]
 ## Composing custom server with Galleon layers
 
-When building a bootable JAR you have the ability to select the set of https://docs.wildfly.org/20/Admin_Guide.html#defined-galleon-layers[WildFly server Galleon layers] 
+When building a bootable JAR you have the ability to select the set of https://docs.wildfly.org/{wildfly-major}/Admin_Guide.html#defined-galleon-layers[WildFly server Galleon layers] 
 you want to see present in the bootable JAR. Selecting a subset of server features has an impact on the server xml configuration 
 and the set of installed JBoss modules. By selecting the subset required by your application you will reduce the JAR size, server configuration content and memory footprint.
 
-You are not limited to the https://docs.wildfly.org/20/Admin_Guide.html#defined-galleon-layers[WildFly defined Galleon layers], you can combine other third parties Galleon layers compatible with 
+You are not limited to the https://docs.wildfly.org/{wildfly-major}/Admin_Guide.html#defined-galleon-layers[WildFly defined Galleon layers], you can combine other third parties Galleon layers compatible with 
 WildFly (eg: https://github.com/wildfly-extras/wildfly-datasources-galleon-pack[WildFly database drivers and datasources layers]). 
-The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/postgresql[postgresql] 
+The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/postgresql[postgresql] 
 shows how to create a _cloud-server_ with support for _postgresql_ database.
 
+[[wildfly_jar_composing_custom_server_galleon_version]]
 ### Specifying the WildFly server version to use
 
 You need to provide a reference to the WildFly Galleon producer that contains the layers you want to use. This can be done in 3 ways.
 
+[[wildfly_jar_composing_custom_server_galleon_fpl]]
 #### Providing WildFly Galleon feature-pack location
 
 That is the simplest way to reference a WildFly server. 
@@ -66,27 +81,31 @@ The configuration element link:#featurePackLocation[feature-pack-location] conta
 
 Some examples:
 
-* To provision a WildFly 20 server: 
+* To provision a WildFly {wildfly-major} server: 
 
-```
-<feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#20.0.0.Final</feature-pack-location>
-```
+[source,xml,subs=attributes+]
+----
+<feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#{wildfly-major}.0.0.Final</feature-pack-location>
+----
 
 * To provision the latest WildFly server: 
 
-```
+[source,xml,subs=attributes+]
+----
 <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)</feature-pack-location>
-```
+----
 
+[[wildfly_jar_composing_custom_server_galleon_feature_packs]]
 #### Providing a list of Galleon feature-packs
 
 In some cases you will want to combine Galleon layers from multiple sources. In this case you will use the link:#featurePacks[feature-packs] configuration element that contains a list 
-of feature-packs. For example, to provision Galleon layers from WildFly 20 and WildFly extras datasources you would provide:
+of feature-packs. For example, to provision Galleon layers from WildFly {wildfly-major} and WildFly extras datasources you would provide:
 
-```
+[source,xml,subs=attributes+]
+----
 <feature-packs>
     <feature-pack>
-        <location>wildfly@maven(org.jboss.universe:community-universe)#20.0.0.Final</location>
+        <location>wildfly@maven(org.jboss.universe:community-universe)#{wildfly-major}.0.0.Final</location>
     </feature-pack>
     <feature-pack>
         <groupId>org.wildfly</groupId>
@@ -94,18 +113,18 @@ of feature-packs. For example, to provision Galleon layers from WildFly 20 and W
         <version>1.0.6.Final</version>
     </feature-pack>
 </feature-packs>
-```
+----
 
 NB: The list of feature-packs can't be used in conjunction with link:#featurePackLocation[feature-pack-location] element.
 
-
+[[wildfly_jar_composing_custom_server_galleon_provisioning_xml]]
 #### Providing a Galleon provisioning.xml file
 
 For advanced use cases you can fully control the Galleon provisioning by defining the file _galleon/provisioning.xml_. 
 _galleon_ directory must be located in the root directory of your Maven project. A custom file location can be set 
 thanks to the _provisioning-file_ plugin option. 
 
-
+[[wildfly_jar_composing_custom_server_galleon_layers]]
 ### Specifying the set of Galleon layers to use
 
 If no Galleon layers are provided, a microprofile standalone server (with a configuration identical to the 
@@ -114,13 +133,15 @@ In order to reduce the server content to your application needs, use the link:#l
 
 For example, to provision a server containing jaxrs and management support:
 
-```
+[source,xml]
+----
 <layers>
     <layer>jaxrs</layer>
     <layer>management</layer>
 </layers>
-```
+----
 
+[[wildfly_jar_composing_custom_server_galleon_exclude_layers]]
 ### Excluding Galleon layers
 
 In order to exclude layers that are not strictly required, use the link:#excludedLayers[excluded-layers] configuration element.
@@ -128,23 +149,25 @@ In order to exclude layers that are not strictly required, use the link:#exclude
 For example, _jaxrs_ layer (that depends on _web-server_ layer) brings the deployment scanner. The deployment scanner being an optional dependency of the _web-server_ layer 
 it can be excluded:
 
-```
+[source,xml]
+----
 <excluded-layers>
     <layer>deployment-scanner</layer>
 </excluded-layers>
-``` 
+----
 
+[[wildfly_jar_url_context]]
 ## URL context path of deployed application
 
 By default, a WAR deployed inside a bootable JAR is located in the root context ('/'). This can be changed to the WAR file name by using the link:#contextRoot[context-root] configuration element.
 
-
+[[wildfly_jar_hollow_jar]]
 ## Hollow bootable JAR
 
 If your use-case requires it, you can create a bootable JAR that doesn't contain a deployment. It can be handy to re-use a bootable JAR artifact with various deployments.
 Use the link:#hollowJar[hollow-jar] configuration element to create an hollow JAR.
 
-The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/hollow-jar[hollow-jar] shows how to build an hollow JAR.
+The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/hollow-jar[hollow-jar] shows how to build an hollow JAR.
 
 When starting an hollow JAR you can provide the path to a deployment you want to see deployed inside the server. For example:
 
@@ -154,15 +177,16 @@ When starting an hollow JAR you can provide the path to a deployment you want to
 
 NB: In order to have your deployment be located in the root context, name the WAR file _ROOT.war_.
 
+[[wildfly_jar_configuring_build]]
 ## Configuring the server during packaging
 
 In addition to Galleon layers that you can use to configure the server, you can fine tune the server during packaging.
 
 The Maven plugin allows you to:
 
-* Run https://docs.wildfly.org/20/Admin_Guide.html#Command_Line_Interface[WildFly CLI] scripts (see https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/logging[logging] example to configure loggers).
+* Run https://docs.wildfly.org/{wildfly-major}/Admin_Guide.html#Command_Line_Interface[WildFly CLI] scripts (see https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/logging[logging] example to configure loggers).
 * Add extra content that you want to see packaged in the server (eg: _standalone/configuration/application-users.properties_, _standalone/configuration/keystore.jks_, ...).
-The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/https[https] shows how to package a keystore file in the bootable JAR.
+The example https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/https[https] shows how to package a keystore file in the bootable JAR.
 
 NB: The configuration changes applied during packaging are persisted in the server configuration.
 
@@ -172,13 +196,14 @@ IMPORTANT: Using a log4j appender as a `custom-handler` in the logging subsystem
 
 You can workaround this by supplying your own `logging.properties` and defining the path in the `boot-logging-config` configuration property.
 
+[[wildfly_jar_configuring_build_cli]]
 ### WildFly CLI execution during packaging
 
 Part of WildFly CLI command line tool has been integrated in the Maven plugin. The plugin supports execution of CLI script files with a limited set of CLI configuration items.
 
 CLI script files are text files that contain a sequence of WildFly CLI commands. Commands can be CLI defined commands 
 (some builtin commands allowing to achieve complex sequence of server operations) and generic management operations to be sent to the server. Some examples can
-be found in WildFly administration guide https://docs.wildfly.org/20/Admin_Guide.html#CLI_Recipes[CLI recipes chapter].
+be found in WildFly administration guide https://docs.wildfly.org/{wildfly-major}/Admin_Guide.html#CLI_Recipes[CLI recipes chapter].
 
 In the context of Bootable JAR, the script does not need to contain commands to connect to the server or start an embedded server. 
 The Maven plugin handles that for you by starting an embedded server for each group of scripts.
@@ -197,7 +222,9 @@ All scripts present in a ```cli-session``` are executed within a single CLI exec
 NB: The scripts are executed in the order they are defined in the plugin configuration. 
 
 CLI configuration example:
-```
+
+[source,xml]
+----
 <cli-sessions>
   <cli-session>
     <script-files>
@@ -215,8 +242,9 @@ CLI configuration example:
     <resolve-expressions>true</resolve-expressions>
   </cli-session>
 </cli-sessions>
-```
+----
 
+[[wildfly_jar_configuring_cloud]]
 ## Configuring the server for cloud execution
 
 The configuration item ```<cloud></cloud>``` allows to build a bootable JAR for cloud environment. By default the server is configured to run inside an OpenShift context.
@@ -241,39 +269,44 @@ Some examples:
 
 Configure for OpenShift execution:
 
-```
+[source,xml]
+----
 <cloud/>
-```
+----
 
 Configure for OpenShift execution with jgroups authentication enabled:
 
-```
+[source,xml,subs=attributes+]
+----
 <cloud>
   <enable-jgroups-password>true</enable-jgroups-password>
 </cloud>
-```
+----
+
 Configure for kubernetes execution:
 
-```
+[source,xml]
+----
 <cloud>
   <type>kubernetes</type>
 </cloud>
-```
+----
 
+[[wildfly_jar_cloud_jkube]]
 ### OpenShift Deployment using Eclipse JKube
 
 https://github.com/eclipse/jkube[JKube Maven plugin] contains support for WildFly bootable JAR. The 
-https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/jkube[jkube] example shows how to combine
+https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/jkube[jkube] example shows how to combine
 WildFly bootable JAR and JKube Maven plugins in order to deploy an application on OpenShift. 
 
-
+[[wildfly_jar_cloud_operator]]
 ### WildFly OpenShift Operator
 
 The WildFly OpenShift Operator can be used to manage deployments based on image containing a WildFly bootable JAR.
 At boot time, the WildFly bootable JAR dumps in the file ```/opt/jboss/container/wildfly-bootable-jar/install-dir``` its installation path.
 This information is required by the WildFly OpenShift Operator to retrieve transaction logs and call into WildFly CLI.
 
-
+[[wildfly_jar_configuring_runtime]]
 ## Configuring the server at runtime
 
 The server can be configured using WildFly management tooling (WildFly CLI, HAL web console, ...).
@@ -282,6 +315,7 @@ In an OpenShift context, the WildFly CLI tool can be retrieved in the bootable J
 
 NB: Configuration changes are not persisted. Once the server is killed, management updates are lost.
 
+[[wildfly_jar_other_goals]]
 ## Other Maven plugin goals
 
 In addition the main link:#_package[package] goal used to build a bootable JAR, the following goals are available:
@@ -298,6 +332,7 @@ IMPORTANT: In order to shutdown a running bootable JAR (started with 'start' or 
 
 Check the link:#_maven_plugin[Maven plugin documentation] for an exhaustive list of configuration elements usable with each goal.
 
+[[wildfly_jar_dev_mode]]
 ## Development mode (dev mode)
 
 When packaging a bootable JAR, a WildFly server is provisioned and customization (if any) is applied. Rebuilding a bootable JAR each time is time consuming
@@ -342,8 +377,10 @@ When using 'dev', 'run' or 'start' goals you can set the _jvmArguments_ configur
 ----
 
 
+[[wildfly_jar_advanced]]
 ## Advanced usages
 
+[[wildfly_jar_advanced_slim]]
 ### Provisioning a slim bootable JAR
 
 A _slim bootable JAR_ is a JAR that doesn't contain JBoss modules JAR files. The JBoss modules JAR files are retrieved from the local Maven repository.
@@ -351,11 +388,12 @@ Such slim bootable JAR is much smaller and starts faster.
 
 To enable slim bootable JAR use the link:#pluginOptions[plugin-options] configuration element and add to it the _jboss-maven-dist_ element. For example:
 
-```
+[source,xml]
+----
 <plugin-options>
     <jboss-maven-dist/>
 </plugin-options>
-```
+----
 
 When running a slim bootable JAR, the default local Maven repository is used to resolve JBoss modules artifacts 
 (in your development environment it shouldn't require special setup to start the bootable JAR).
@@ -366,6 +404,7 @@ This can be overridden by using the _-Dmaven.repo.local=<path to repository>_ wh
 java -Dmaven.repo.local=/opt/maven/maven-repo -jar jaxrs-bootable.jar
 ```
 
+[[wildfly_jar_advanced_slim_repo_gen]]
 #### Generating a Maven local repository during packaging
 
 The Maven plugin can generate a Maven repository directory containing all the JBoss modules artifacts required by the slim bootable JAR. The generated Maven repository allows to 
@@ -374,14 +413,15 @@ run a slim bootable JAR in a context were no local Maven cache is present.
 To enable slim bootable JAR Maven repository generation, use the link:#pluginOptions[plugin-options] configuration element and add to it the _jboss-maven-dist_ and 
 _jboss-maven-repo_ elements. For example:
 
-```
+[source,xml]
+----
 <plugin-options>
     <jboss-maven-dist/>
-    <jboss-maven-repo>./my-maven-repo</jboss-maven-repo>
+    <jboss-maven-repo>target/my-maven-repo</jboss-maven-repo>
 </plugin-options>
-```
+----
 
 In this example, the directory _./my-maven-repo_ is created and contains the set of JBoss modules JAR required to start the server.
  
-The https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/slim[slim] example shows how to build a slim bootable JAR 
+The https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/slim[slim] example shows how to build a slim bootable JAR 
 and generate a local Maven repository used at startup.

--- a/docs/guide/maven-plugin/index.adoc
+++ b/docs/guide/maven-plugin/index.adoc
@@ -3,12 +3,12 @@
 This chapter is dedicated to the Maven plugin that can be used to build WildFly bootable JAR. Maven
 coordinates of the Maven plugin artifact are
 
-[source,xml]
+[source,xml,subs=attributes+]
 ----
 <dependency>
     <groupId>org.wildfly.plugins</groupId>
     <artifactId>wildfly-jar-maven-plugin</artifactId>
-    <version>2.0.0.Beta9-SNAPSHOT</version>
+    <version>{revnumber}</version>
 </dependency>
 ----
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -26,7 +26,7 @@
     <version>2.0.0.Beta9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>docs</artifactId>
+  <artifactId>wildfly-jar-docs</artifactId>
   <packaging>pom</packaging>
 
   <name>WildFly Bootable jar Docs</name>
@@ -79,6 +79,8 @@
                 <source-highlighter>coderay</source-highlighter>
                 <coderay-css>style</coderay-css>
                 <toclevels>2</toclevels>
+                <project-branch>${docs.project.branch}</project-branch>
+                <wildfly-major>${docs.wildfly.major}</wildfly-major>
               </attributes>
             </configuration>
           </execution>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,39 +1,6 @@
-Each directory contains a specific use-case in which wildfly bootable jar maven plugin is used. Each example contains a README.md file
-that contains the information to build and run the example. NB: The released examples depend on the released plugin. In the master branch,
+Each directory (except the _scripts_ directory that contains WildFly CLI scripts shared by some examples) 
+contains an example that covers a specific use-case in which WildFly bootable JAR Maven plugin is used. Each directory contains a README.md file
+that contains the information to build and run the example. 
+
+NB: The released examples depend on the released plugin. In the master branch,
 the examples depend on the SNAPSHOT build of the plugin.
-
-
-JDK11 required arguments
-========================
-
-When running on JDK11, the following options should be used:
-
-* --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-* --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
-* --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
-
-Openshift binary build and deployment
-=====================================
-The JDK11 openshift builder image can be used to build/run these example applications. To import the image in openshift:
-
-* oc import-image openjdk11 --from=registry.access.redhat.com/openjdk/openjdk-11-rhel7 --confirm
-
-JVM ENV variable required for Openshift
-=======================================
-
-* GC_MAX_METASPACE_SIZE=256
-* GC_METASPACE_SIZE=96
-* JAVA_OPTS=-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true
-
-Enable Debug for Openshift
-==========================
-
-Env variables to enable debug:
-* JAVA_DEBUG=true
-* JAVA_DEBUG_PORT=8787
-
-Port forwarding
-* oc get pods
-* oc port-forward <pod name> 8787:8787
-
-Attach your debugger to 127.0.0.1:8787

--- a/examples/authentication/pom.xml
+++ b/examples/authentication/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
     <artifactId>authentication</artifactId>
     <packaging>war</packaging>

--- a/examples/hollow-jar/pom.xml
+++ b/examples/hollow-jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>default-hollow-jar</artifactId>

--- a/examples/https/pom.xml
+++ b/examples/https/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>https</artifactId>

--- a/examples/jaxrs/pom.xml
+++ b/examples/jaxrs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs</artifactId>

--- a/examples/jib-layers/README.md
+++ b/examples/jib-layers/README.md
@@ -1,9 +1,9 @@
 # JAX-RS WildFly bootable jar Jib generated image
 
-We are using the packaged jar and WAR support of Java Image Builder Jib.
-This example separates the creation of a hollow bootable jar Jib image from the application JIB image. This allows for efficient application image build. The bootable jar is built only once.
+We are using the packaged JAR and WAR support of Java Image Builder Jib.
+This example separates the creation of a hollow bootable JAR Jib image from the application JIB image. This allows for efficient application image build. The bootable JAR is built only once.
 
-* To build the hollow jar JIB image
+* To build the hollow JAR JIB image
 
   * cd server-layer
   * mvn package

--- a/examples/jib-layers/app-layer/pom.xml
+++ b/examples/jib-layers/app-layer/pom.xml
@@ -4,9 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wildfly.plugins</groupId>
-        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <artifactId>jib-layers-parent</artifactId>
         <version>2.0.0.Beta9-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jib-app-layer</artifactId>
     <packaging>war</packaging>

--- a/examples/jib-layers/app-layer/pom.xml
+++ b/examples/jib-layers/app-layer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jib-app-layer</artifactId>

--- a/examples/jib-layers/pom.xml
+++ b/examples/jib-layers/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
+    </parent>
+    <artifactId>jib-layers-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>WildFly Bootable JAR - JAX-RS with jib layers parent</name>
+    <description>JAX-RS running with jib Example parent</description>
+
+    <modules>
+        <module>server-layer</module>
+        <module>app-layer</module>
+    </modules>
+</project>

--- a/examples/jib-layers/server-layer/pom.xml
+++ b/examples/jib-layers/server-layer/pom.xml
@@ -4,9 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wildfly.plugins</groupId>
-        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <artifactId>jib-layers-parent</artifactId>
         <version>2.0.0.Beta9-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>jib-server-layer</artifactId>

--- a/examples/jib-layers/server-layer/pom.xml
+++ b/examples/jib-layers/server-layer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jib-operator/pom.xml
+++ b/examples/jib-operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
     <artifactId>jaxrs-jib-operator</artifactId>
     <packaging>jar</packaging>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
     <artifactId>jaxrs-jib</artifactId>
     <packaging>jar</packaging>

--- a/examples/jkube/pom.xml
+++ b/examples/jkube/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
     <artifactId>jkube-app</artifactId>
     <packaging>war</packaging>

--- a/examples/logging/pom.xml
+++ b/examples/logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>logging</artifactId>

--- a/examples/microprofile-config/pom.xml
+++ b/examples/microprofile-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>microprofile-config</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -57,8 +57,7 @@
         <module>https</module>
         <module>jaxrs</module>
         <module>jib</module>
-        <module>jib-layers/app-layer</module>
-        <module>jib-layers/server-layer</module>
+        <module>jib-layers</module>
         <module>jib-operator</module>
         <module>jkube</module>
         <module>logging</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wildfly.plugins</groupId>
     <artifactId>wildfly-jar-examples-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0.Beta9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WildFly Bootable JAR - Examples</name>

--- a/examples/postgresql/pom.xml
+++ b/examples/postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>postgresql</artifactId>

--- a/examples/secmanager/pom.xml
+++ b/examples/secmanager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>sec-manager</artifactId>

--- a/examples/slim/pom.xml
+++ b/examples/slim/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>slim</artifactId>

--- a/examples/web-clustering/pom.xml
+++ b/examples/web-clustering/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-jar-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0.Beta9-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-clustering</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
 
   <properties>
     <version.wildfly>21.0.0.Beta1</version.wildfly>
+    <!-- docs properties -->
+    <docs.project.branch>master</docs.project.branch>
+    <docs.wildfly.major>20</docs.wildfly.major>
 
     <version.junit>4.12</version.junit>
     <version.org.apache.maven.core>3.3.1</version.org.apache.maven.core>

--- a/release_process.adoc
+++ b/release_process.adoc
@@ -10,14 +10,22 @@ First, make sure you don't have pending changes in your master branch.
 * Update in pom.xml docs.project.branch to reference the new release
 * Update in pom.xml docs.wildfly.major to reference the WildFly major release (if a new WildFly final release on which the plugin depends has been released).
 * Update the examples/pom.xml file to reference the released plugin
-* Update examples/pom.xml and examples/**/poml.xml with the release version.
+* Update the examples version:
+** cd examples
+** mvn versions:set -DnewVersion=<new released version>
+** mvn versions:commit
+** cd ..
 * Commit the changes with message: `Update docs and examples to X.X.X.Final`
 * mvn clean install to run tests.
 * `mvn release:prepare -Darguments="-DskipTests"`
 * `mvn release:perform -Darguments="-DskipTests"`
 * Update in pom.xml docs.project.branch to reference master
-* Update the examples/pom.xml file to reference the released plugin
-* Update examples/pom.xml and examples/**/poml.xml with the release version.
+* Update the examples/pom.xml file to reference the snapshot plugin
+* Update the examples version:
+** cd examples
+** mvn versions:set -DnewVersion=<new snapshot version>
+** mvn versions:commit
+** cd ..
 * Commit the changes with message: `Update docs and examples to X.X.X.Final-SNAPSHOT`
 * `git push upstream master`
 

--- a/release_process.adoc
+++ b/release_process.adoc
@@ -7,18 +7,19 @@ First, make sure you don't have pending changes in your master branch.
 * `cd wildfly-jar-maven-plugin`
 * `git checkout master`
 * `pull --rebase upstream master`
-* Update docs/* content to reference the new released version. 
-* Commit the changes with message: `Update doc to X.X.X.Final`
+* Update in pom.xml docs.project.branch to reference the new release
+* Update in pom.xml docs.wildfly.major to reference the WildFly major release (if a new WildFly final release on which the plugin depends has been released).
 * Update the examples/pom.xml file to reference the released plugin
-* Commit the changes with message: `Update examples to X.X.X.Final`
+* Update examples/pom.xml and examples/**/poml.xml with the release version.
+* Commit the changes with message: `Update docs and examples to X.X.X.Final`
 * mvn clean install to run tests.
 * `mvn release:prepare -Darguments="-DskipTests"`
 * `mvn release:perform -Darguments="-DskipTests"`
-* Update docs/* content to reference the new SNAPSHOT version. 
-* Commit the changes with message: `Update doc to X.X.X.Final-SNAPSHOT`
-* Update the examples/pom.xml file to reference the new SNAPSHOT version.
-* Commit the changes with message: `Update examples to X.X.X.Final-SNAPSHOT`
-* `push upstream master`
+* Update in pom.xml docs.project.branch to reference master
+* Update the examples/pom.xml file to reference the released plugin
+* Update examples/pom.xml and examples/**/poml.xml with the release version.
+* Commit the changes with message: `Update docs and examples to X.X.X.Final-SNAPSHOT`
+* `git push upstream master`
 
 == STEP 2: Release in Nexus
 

--- a/release_process.adoc
+++ b/release_process.adoc
@@ -17,6 +17,7 @@ First, make sure you don't have pending changes in your master branch.
 ** cd ..
 * Commit the changes with message: `Update docs and examples to X.X.X.Final`
 * mvn clean install to run tests.
+* Validate that all examples build: `cd examples && mvn clean package`
 * `mvn release:prepare -Darguments="-DskipTests"`
 * `mvn release:perform -Darguments="-DskipTests"`
 * Update in pom.xml docs.project.branch to reference master


### PR DESCRIPTION
* Introduced some asciidoc attributes to adapt documentation to release.
* Added doc chapter links.
* Make examples version to be 2.0.0.Beta9-SNAPSHOT
* Adjusted jib-layers example to be able to build all examples from examples directory.
* Reworked release_process.adoc to document new steps.
