### PR TITLE
Fix for Issue #135, Add examples to cover arquillian support

### DIFF
--- a/examples/arquillian/hollow-jar/README.md
+++ b/examples/arquillian/hollow-jar/README.md
@@ -1,0 +1,15 @@
+# Hollow JAR / Arquillian testing example
+
+Arquillian is used to deploy a JAX-RS resource and an EJB into the Hollow JAR.
+
+In this scenario, part of the Arquillian test is run as a client 
+(testcase annotated with ```@RunAsClient```) and in-container.
+
+The Arquillian XML descriptor is located in _src/test/resources/arquillian.xml_
+
+Build, test and run
+===================
+
+* To build and run tests: `mvn clean verify`
+* To run: `mvn wildfly-jar:run`
+* Access the application: `http://127.0.0.1:8080/hello`

--- a/examples/arquillian/hollow-jar/pom.xml
+++ b/examples/arquillian/hollow-jar/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-arquillian-tests-parent</artifactId>
+        <version>2.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hollow-jar-arquillian</artifactId>
+    <packaging>jar</packaging>
+
+    <name>WildFly Bootable JAR - Hollow JAR Example tested with Arquillian</name>
+    <description>An example of an Hollow JAR tested using Arquillian</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-bootable</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+      
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                    <layers>
+                        <layer>jaxrs</layer>
+                        <layer>management</layer>
+                        <layer>cdi</layer>
+                        <layer>ejb-lite</layer>
+                    </layers>
+                    <excluded-layers>
+                        <layer>deployment-scanner</layer>
+                    </excluded-layers>
+                    <plugin-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </plugin-options>
+                    <hollow-jar>true</hollow-jar>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jaxrs.surefire</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <failIfNoTests>true</failIfNoTests>
+                            <systemPropertyVariables>
+                                <bootable.jar>${project.build.directory}/hollow-jar-arquillian-bootable.jar</bootable.jar>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/GreeterEJB.java
+++ b/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/GreeterEJB.java
@@ -1,0 +1,20 @@
+package org.wildfly.plugins.demo.hollowjar;
+
+import javax.ejb.Stateful;
+
+/**
+ * A simple Hello World EJB. The EJB does not use an interface.
+ *
+ */
+@Stateful
+public class GreeterEJB {
+    /**
+     * This method takes a name and returns a personalised greeting.
+     *
+     * @param name the name of the person to be greeted
+     * @return the personalised greeting.
+     */
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+}

--- a/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/HelloWorldEndpoint.java
+++ b/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/HelloWorldEndpoint.java
@@ -1,0 +1,17 @@
+package org.wildfly.plugins.demo.hollowjar;
+
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+    @GET
+    @Produces("text/plain")
+    public Response doGet() {
+        return Response.ok("Hello from WildFly bootable jar!").build();
+    }
+}

--- a/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/HollowJarITCase.java
+++ b/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/HollowJarITCase.java
@@ -1,0 +1,45 @@
+package org.wildfly.plugins.demo.hollowjar;
+
+import java.net.URL;
+import javax.ejb.EJB;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class HollowJarITCase {
+
+    @EJB(mappedName = "java:module/GreeterEJB")
+    private GreeterEJB ejb;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testapp.war");
+        war.addClass(GreeterEJB.class);
+        war.addClass(HelloWorldEndpoint.class);
+        war.addClass(RestApplication.class);
+        return war;
+    }
+
+    @Test
+    @RunAsClient
+    public void testURL(@ArquillianResource URL url) throws Exception {
+        String result = TestUtil.performCall(new URL(url.toString() + "hello"));
+        assertEquals(result, "Hello from WildFly bootable jar!", result);
+    }
+
+    @Test
+    public void testEjb() throws Exception {
+        assertNotNull(ejb);
+    }
+
+}

--- a/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/RestApplication.java
+++ b/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.plugins.demo.hollowjar;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+}

--- a/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/TestUtil.java
+++ b/examples/arquillian/hollow-jar/src/test/java/org/wildfly/plugins/demo/hollowjar/TestUtil.java
@@ -1,0 +1,46 @@
+package org.wildfly.plugins.demo.hollowjar;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class TestUtil {
+
+    static String performCall(URL url) throws Exception {
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoInput(true);
+        return processResponse(conn);
+    }
+
+    private static String processResponse(HttpURLConnection conn) throws IOException {
+        int responseCode = conn.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            final InputStream err = conn.getErrorStream();
+            try {
+                String response = err != null ? read(err) : null;
+                throw new IOException(String.format("HTTP Status %d Response: %s", responseCode, response));
+            } finally {
+                if (err != null) {
+                    err.close();
+                }
+            }
+        }
+        final InputStream in = conn.getInputStream();
+        try {
+            return read(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    private static String read(final InputStream in) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        return out.toString();
+    }
+}

--- a/examples/arquillian/hollow-jar/src/test/resources/arquillian.xml
+++ b/examples/arquillian/hollow-jar/src/test/resources/arquillian.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="bootable-jar" default="true">
+        <configuration>
+            <property name="jarFile">${bootable.jar}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/examples/arquillian/jaxrs/README.md
+++ b/examples/arquillian/jaxrs/README.md
@@ -1,0 +1,14 @@
+# JAX-RS / Arquillian testing example
+
+Build a bootable JAR containing a JAX-RS resource and test it using Arquillian.
+
+In this scenario, the Arquillian test is run as a client (test annotated with ```@RunAsClient```).
+
+The Arquillian XML descriptor is located in _src/test/resources/arquillian.xml_
+
+Build, test and run
+===================
+
+* To build and run tests: `mvn clean verify`
+* To run: `mvn wildfly-jar:run`
+* Access the application: `http://127.0.0.1:8080/hello`

--- a/examples/arquillian/jaxrs/pom.xml
+++ b/examples/arquillian/jaxrs/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-arquillian-tests-parent</artifactId>
+        <version>2.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jaxrs-arquillian</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly Bootable JAR - JAX-RS Example tested with Arquillian</name>
+    <description>An example of how to use JAX-RS resources and test it using Arquillian</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-bootable</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                    <layers>
+                        <layer>jaxrs</layer>
+                        <layer>management</layer>
+                    </layers>
+                    <excluded-layers>
+                        <layer>deployment-scanner</layer>
+                    </excluded-layers>
+                    <plugin-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </plugin-options>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jaxrs.surefire</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+
+                        </goals>
+                        <configuration>
+                            <failIfNoTests>true</failIfNoTests>
+                            <systemPropertyVariables>
+                                <bootable.jar>${project.build.directory}/jaxrs-arquillian-bootable.jar</bootable.jar>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/arquillian/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/HelloWorldEndpoint.java
+++ b/examples/arquillian/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/HelloWorldEndpoint.java
@@ -1,0 +1,17 @@
+package org.wildfly.plugins.demo.jaxrs;
+
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+    @GET
+    @Produces("text/plain")
+    public Response doGet() {
+        return Response.ok("Hello from WildFly bootable jar!").build();
+    }
+}

--- a/examples/arquillian/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/RestApplication.java
+++ b/examples/arquillian/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.plugins.demo.jaxrs;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+}

--- a/examples/arquillian/jaxrs/src/test/java/org/wildfly/plugins/demo/jaxrs/JaxrsITCase.java
+++ b/examples/arquillian/jaxrs/src/test/java/org/wildfly/plugins/demo/jaxrs/JaxrsITCase.java
@@ -1,0 +1,25 @@
+package org.wildfly.plugins.demo.jaxrs;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JaxrsITCase {
+
+
+    @Test
+    public void testURL() throws Exception {
+        String result = TestUtil.performCall(new URL("http://127.0.0.1:8080/hello"));
+        System.out.println("RESULT " + result);
+        assertEquals(result, "Hello from WildFly bootable jar!", result);
+    }
+
+}

--- a/examples/arquillian/jaxrs/src/test/java/org/wildfly/plugins/demo/jaxrs/TestUtil.java
+++ b/examples/arquillian/jaxrs/src/test/java/org/wildfly/plugins/demo/jaxrs/TestUtil.java
@@ -1,0 +1,46 @@
+package org.wildfly.plugins.demo.jaxrs;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class TestUtil {
+
+    static String performCall(URL url) throws Exception {
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoInput(true);
+        return processResponse(conn);
+    }
+
+    private static String processResponse(HttpURLConnection conn) throws IOException {
+        int responseCode = conn.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            final InputStream err = conn.getErrorStream();
+            try {
+                String response = err != null ? read(err) : null;
+                throw new IOException(String.format("HTTP Status %d Response: %s", responseCode, response));
+            } finally {
+                if (err != null) {
+                    err.close();
+                }
+            }
+        }
+        final InputStream in = conn.getInputStream();
+        try {
+            return read(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    private static String read(final InputStream in) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        return out.toString();
+    }
+}

--- a/examples/arquillian/jaxrs/src/test/resources/arquillian.xml
+++ b/examples/arquillian/jaxrs/src/test/resources/arquillian.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="bootable-jar" default="true">
+        <configuration>
+            <property name="jarFile">${bootable.jar}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/examples/arquillian/pom.xml
+++ b/examples/arquillian/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <version>2.0.0.Final-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-jar-arquillian-tests-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>WildFly Bootable JAR - arquillian tests parent</name>
+    <description>Arquillian to test WildFly bootable JAR</description>
+
+    <modules>
+        <module>jaxrs</module>
+        <module>hollow-jar</module>
+    </modules>
+</project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,6 +21,10 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.microprofile.bom>${version.wildfly}</version.microprofile.bom>
         <version.server.bom>${version.wildfly}</version.server.bom>
+        <version.org.wildfly.arquillian>3.0.0.Final</version.org.wildfly.arquillian>
+        <version.org.jboss.arquillian.junit>1.6.0.Final</version.org.jboss.arquillian.junit>
+        <version.junit>4.12</version.junit>
+        <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
     </properties>
 
     <dependencyManagement>
@@ -35,7 +39,7 @@
             <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
-                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <artifactId>wildfly-jakartaee8</artifactId>
                 <version>${version.server.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -49,10 +53,37 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.junit</groupId>
+                <artifactId>arquillian-junit-container</artifactId>
+                <version>${version.org.jboss.arquillian.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-api</artifactId>
+                <version>${version.org.jboss.shrinkwrap.shrinkwrap}</version>
+            </dependency>
+      
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-impl-base</artifactId>
+                <version>${version.org.jboss.shrinkwrap.shrinkwrap}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <modules>
+        <module>arquillian</module>
         <module>authentication</module>
         <module>ejb-in-ear</module>
         <module>ejb-in-war</module>


### PR DESCRIPTION
Add 2 new tests that cover what wildfly-arquillian currently supports

* Hollow JAR with a mix of client/in-container scenario
* JAR with client only scenario.

@jamezp I had to change the dependency on boms from wildfly-jakartaee8-with-tools to wildfly-jakartaee8. The bom created a version mismatch for arquillian. I added a dependency on wildfly-arquillian 3.0.0.Final.

That raises a question. 
What will be the wildfly-arquillian version in WF 21 boms? 3.0.0.Final I guess (WF has just been upgraded). Should the wildfly-jakartaee8-with-tools contains the org.wildfly.arquillian:wildfly-arquillian-container-bootable dependency?

@yersan do we really need wildfly-jakartaee8-with-tools? Can we rely on wildfly-jakartaee8 bom?


