### PR TITLE
Depend on SNAPSHOT, build WildFly master in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: main
+      
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
@@ -33,8 +36,68 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Initialise Bootable JAR WildFly version
+        # Needed to download everything from Maven to not pollute the output in the next steps
+        run: |
+          mvn -B help:evaluate -Dexpression=version.wildfly -pl :wildfly-jar-parent
+        working-directory: main
+      - name: Initialise BOOTABLE_JAR_WILDFLY_VERSION
+        run: |
+          TMP="$(mvn help:evaluate -Dexpression=version.wildfly -pl :wildfly-jar-parent | grep -v '^\[')"
+          echo "::set-env name=BOOTABLE_JAR_WILDFLY_VERSION::${TMP}"
+        working-directory: main
+      - name: Checkout wildfly master
+        # WildFly master is built only if the dependency is a SNAPSHOT
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        uses: actions/checkout@v2
+        with:
+          repository: wildfly/wildfly
+          path: wildfly-master
+      - name: Initialise WildFly version
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        # Needed to download everything from Maven to not pollute the output in the next steps
+        run: |
+          mvn -B help:evaluate -Dexpression=project.version -pl :wildfly-parent
+        working-directory: wildfly-master
+      - name: Initialize WILDFLY_VERSION
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        run: |
+          TMP="$(mvn help:evaluate -Dexpression=project.version -pl :wildfly-parent | grep -v '^\[')"
+          echo "::set-env name=WILDFLY_VERSION::${TMP}"
+        working-directory: wildfly-master
+      - name: Check SNAPSHOT versions match
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        run: |
+          echo "Actual WildFly version in master branch: ${WILDFLY_VERSION}"
+          echo "WildFly version in bootable JAR project: ${BOOTABLE_JAR_WILDFLY_VERSION}"
+          if [ "${BOOTABLE_JAR_WILDFLY_VERSION}" != "${WILDFLY_VERSION}" ]; then
+            echo "SNAPSHOT versions don't match, update version.wildfly to ${WILDFLY_VERSION} "
+            exit 1;
+          fi
+      - name: Build WildFly master
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        run: mvn -B install -DskipTests
+        working-directory: wildfly-master
+      - name: Set BOOTABLE_JAR_VERSION used to run WildFly master branch tests
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        run: |
+          TMP="$(mvn help:evaluate -Dexpression=project.version -pl :wildfly-jar-parent | grep -v '^\[')"
+          echo "::set-env name=BOOTABLE_JAR_VERSION::${TMP}"
+        working-directory: main
+   
+      # End build WildFly master
+   
       - name: Build and Test on ${{ matrix.java }}
-        run: mvn clean install '-Dtest.jvm.args=-Dorg.wildfly.logging.skipLogManagerCheck=true'
+        run: mvn -B install '-Dtest.jvm.args=-Dorg.wildfly.logging.skipLogManagerCheck=true' -Dversion.wildfly=${BOOTABLE_JAR_WILDFLY_VERSION}
+        working-directory: main
+   
+      # Run some tests to check that WildFly bootable JAR tests are ok.   
+      
+      - name: Run WildFly microprofile master bootable JAR tests (sanity check the plugin)
+        if: contains(env.BOOTABLE_JAR_WILDFLY_VERSION, 'SNAPSHOT')
+        run: mvn -B install install -pl microprofile -Dts.bootable -Dversion.org.wildfly.jar.plugin=${BOOTABLE_JAR_VERSION}
+        working-directory: wildfly-master/testsuite/integration
+        
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/README.md
+++ b/README.md
@@ -46,5 +46,9 @@ Some examples are targeting OpenShift deployment, for example:
 
 ## Building the project
 
-* Clone this repository project.
-* Call: `mvn clean install -DskipTests`
+The master branch depends on latest WildFly that you need to build locally.
+
+* git clone https://github.com/wildfly/wildfly
+* mvn clean install -DskipTests
+* git clone https://github.com/wildfly-extras/wildfly-jar-maven-plugin
+* mvn clean install -DskipTests

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <version.bootable.jar>3.0.0.Beta1-SNAPSHOT</version.bootable.jar>
-        <version.wildfly>21.0.0.Final</version.wildfly>
+        <version.wildfly>22.0.0.Beta1-SNAPSHOT</version.wildfly>
         <version.jkube>1.0.1</version.jkube>
         <plugin.fork.embedded>true</plugin.fork.embedded>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   </modules>
 
   <properties>
-    <version.wildfly>21.0.0.Final</version.wildfly>
+    <version.wildfly>22.0.0.Beta1-SNAPSHOT</version.wildfly>
     <!-- docs properties -->
     <docs.project.branch>master</docs.project.branch>
     <docs.wildfly.major>21</docs.wildfly.major>
@@ -78,7 +78,7 @@
 
     <maven.test.skip>false</maven.test.skip>
     <skipTests>${maven.test.skip}</skipTests>
-    
+    <surefire.tests.redirectTestOutputToFile>true</surefire.tests.redirectTestOutputToFile>
     <test.fpl>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.fpl>
     <test.patch.product>WildFly Full</test.patch.product>
     <test.patch.version>${version.wildfly}</test.patch.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -184,7 +184,7 @@
                                     <value>${jbossas.dist}</value>
                                 </property>
                             </systemProperties>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>${surefire.tests.redirectTestOutputToFile}</redirectTestOutputToFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
POC DO NOT MERGE!

* Depend on a SNAPSHOT build of WildFly for tests and examples.
* Add github actions steps to build WildFly.
 * WF is built only if the dependency is a SNAPSHOT (not a WF release that we use when releasing a plugin).
 * If SNAPSHOT versions don't match, the CI job aborts, the project needs to upgrade to the latest WildFly SNAPSHOT.
* Add github actions step to run WildFly microprofile -Dts.bootable tests (only when a SNAPSHOT has been built).

