### PR TITLE
Fix for Issue #149, Add an example to cover MDB and RAR deployment

### DIFF
--- a/examples/mdb-rar/README.md
+++ b/examples/mdb-rar/README.md
@@ -1,0 +1,29 @@
+# WildFly MDB and RAR deployment application example
+
+This example shows how to package an activemq resource adapter in order for an 
+MDB to consume messages emitted by the activemq server. 
+
+Start the activemq server
+=========================
+
+* Download the server from https://activemq.apache.org/components/classic/download/
+* Start the server: `bin/activemq start`
+
+Download the rar file
+=====================
+
+* It is available in Maven repository: `https://search.maven.org/search?q=a:activemq-rar`
+* Copy the rar in the current directory as `activemq-rar.rar`.
+* NB: the script `deploy-rar.cli` is called when building the bootable JAR to deploy the rar archive.
+ 
+Build and run
+=============
+
+* To build: `mvn package`
+* To run: `mvn wildfly-jar:run`
+
+Produce Messages from the activemq CLI
+======================================
+
+* `bin/activemq producer --destination queue://java:jboss/activemq/queue/LocalRPCRequest`
+* You will notice that the MDB prints the received messages in the console.

--- a/examples/mdb-rar/deploy-rar.cli
+++ b/examples/mdb-rar/deploy-rar.cli
@@ -1,0 +1,2 @@
+deploy activemq-rar.rar
+/subsystem=resource-adapters/resource-adapter=activemq-rar.rar:add(archive=activemq-rar.rar,transaction-support=LocalTransaction)

--- a/examples/mdb-rar/pom.xml
+++ b/examples/mdb-rar/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <version>3.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mdb-rar</artifactId>
+    <packaging>jar</packaging>
+
+    <name>WildFly Bootable Jar - MDB and RAR deployment</name>
+    <description>This project demonstrates how to package an MDB and a RAR.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                    <layers>
+                        <layer>ejb</layer>
+                    </layers>
+                    <plugin-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </plugin-options>
+                    <cli-sessions>
+                        <cli-session>
+                            <script-files>
+                                <script>deploy-rar.cli</script>
+                            </script-files>
+                        </cli-session>
+                    </cli-sessions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/mdb-rar/src/main/java/org/wildfly/plugins/demo/mdb/ActiveMQMDB.java
+++ b/examples/mdb-rar/src/main/java/org/wildfly/plugins/demo/mdb/ActiveMQMDB.java
@@ -1,0 +1,33 @@
+package org.wildfly.plugins.demo.mdb;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import org.jboss.ejb3.annotation.ResourceAdapter;
+
+@MessageDriven(
+        activationConfig = {
+            @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+            @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/activemq/queue/LocalRPCRequest")
+        },
+        name = "ActiveMQMDB")
+@ResourceAdapter(value = "activemq-rar.rar")
+public class ActiveMQMDB implements MessageListener {
+
+    public ActiveMQMDB() {
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            if (message instanceof TextMessage) {
+                System.out.println("Got Message " + ((TextMessage) message).getText());
+            }
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Simple bootable JAR based on the ejb layer containing an MDB that consumes messages.