### PR TITLE
Revisit fix for #176, cloud support, do not add repl cache if jgroups not in config

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
@@ -55,6 +55,7 @@ public class CloudConfig {
         "openshift-undertow-script.cli",
         "openshift-tx-script.cli",
         "openshift-clustering-script.cli",
+        "openshift-infinispan-script.cli",
         "openshift-webservices-script.cli"};
 
     //Can be openshift or kubernetes
@@ -109,13 +110,8 @@ public class CloudConfig {
         // Must be done first before to modify the config with static script
         Path p = mojo.getJBossHome();
         Path config = p.resolve("standalone").resolve("configuration").resolve("standalone.xml");
-        boolean jgroups = JGroupsUtil.containsJGroups(config);
         if (enableJgroupsPassword) {
             commands.addAll(JGroupsUtil.getAuthProtocolCommands(config));
-        }
-        if (jgroups) {
-            // Can only add repl cache if jgroups is present.
-            addCommands("openshift-infinispan-script.cli", commands);
         }
         for (String script : CLI_SCRIPTS) {
             addCommands(script, commands);

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/JGroupsUtil.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/JGroupsUtil.java
@@ -83,16 +83,4 @@ public class JGroupsUtil {
             return (NodeList) xpath.evaluate("//subsystem", root, XPathConstants.NODESET);
         }
     }
-
-    static boolean containsJGroups(Path configFile) throws Exception {
-        NodeList lst = getSubSystems(configFile);
-        for (int i = 0; i < lst.getLength(); i++) {
-            Element subsystem = (Element) lst.item(i);
-            String xmlns = subsystem.getAttribute("xmlns");
-            if (xmlns.startsWith("urn:jboss:domain:jgroups:")) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-infinispan-script.cli
+++ b/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-infinispan-script.cli
@@ -1,5 +1,5 @@
-# Infinispan, add a more efficient cache.
-if (outcome == success) of /subsystem=infinispan/cache-container=web:read-resource
+# Infinispan, add a more efficient cache if we already have the dist distributed cache.
+if (outcome == success) of /subsystem=infinispan/cache-container=web/distributed-cache=dist:read-resource
   /subsystem=infinispan/cache-container=web/replicated-cache=repl:add
   /subsystem=infinispan/cache-container=web:write-attribute(name=default-cache,value=repl)
   /subsystem=infinispan/cache-container=web/replicated-cache=repl/component=locking:add(isolation=REPEATABLE_READ


### PR DESCRIPTION
Simpler fis, keep infinispan script separated from jgroups.