### PR TITLE
Test case for Issue #185, test-source retrieved from jboss-parent

### DIFF
--- a/tests/src/test/resources/projects/jaxrs/pom.xml
+++ b/tests/src/test/resources/projects/jaxrs/pom.xml
@@ -2,6 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>37</version>
+    </parent>
     <groupId>org.wildfly.plugins.tests</groupId>
     <version>1.0.0.Final-SNAPSHOT</version>
     <artifactId>test1</artifactId>


### PR DESCRIPTION
By having the pom.xml inherits from jboss-pearent, we are getting complex compiler configuration that was causing WildFly quickstarts to break with dev-watch goal.