### PR TITLE
Upgrade WildFly Components

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <version.bootable.jar>4.0.0.Beta2-SNAPSHOT</version.bootable.jar>
         <version.keycloak>12.0.1</version.keycloak>
-        <version.wildfly>23.0.0.Beta1</version.wildfly>
+        <version.wildfly>23.0.0.Final</version.wildfly>
         <version.jkube>1.0.1</version.jkube>
         <plugin.fork.embedded>true</plugin.fork.embedded>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
   </modules>
 
   <properties>
-    <version.wildfly>23.0.0.Beta1</version.wildfly>
+    <version.wildfly>23.0.0.Final</version.wildfly>
     <!-- docs properties -->
     <docs.project.branch>master</docs.project.branch>
-    <docs.wildfly.major>22</docs.wildfly.major>
+    <docs.wildfly.major>23</docs.wildfly.major>
 
     <version.junit>4.13.1</version.junit>
     <version.org.apache.maven.core>3.3.1</version.org.apache.maven.core>
@@ -82,7 +82,7 @@
     
     <test.fpl>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.fpl>
     <test.version.wildfly>${version.wildfly}</test.version.wildfly>
-    <test.version.wildfly-ee.upgrade>22.0.0.Final</test.version.wildfly-ee.upgrade>
+    <test.version.wildfly-ee.upgrade>23.0.0.Final</test.version.wildfly-ee.upgrade>
     <test.patch.product>WildFly Full</test.patch.product>
     <test.patch.version>${version.wildfly}</test.patch.version>
     <wildfly.artifactId>wildfly-galleon-pack</wildfly.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <version.org.apache.maven.plugin-tools>3.5.1</version.org.apache.maven.plugin-tools>
     <version.org.asciidoctor>2.0.0</version.org.asciidoctor>
     <version.org.jboss.galleon>4.2.7.Final</version.org.jboss.galleon>
-    <version.org.wildfly.core.wildfly-core>15.0.0.Beta1</version.org.wildfly.core.wildfly-core>
+    <version.org.wildfly.core.wildfly-core>15.0.0.Final</version.org.wildfly.core.wildfly-core>
     <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.wildfly.plugins.wildfly-maven-plugin>2.0.1.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
     <!-- required by tests -->


### PR DESCRIPTION
@jfdenise I just thought I'd submit this however `PatchUnexistingFailModuleTestCase.testUpdateModulePatch` is failing and only seems to work with 23.0.0.Beta1.