### PR TITLE
Fix for Issue #216, Evolve artifact upgrade to narrow upgrade inside a feature-pack

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -506,7 +506,16 @@ Each artifact version is the one that would get installed when building the Boot
 
 The Maven artifacts to upgrade must be added to the `<dependencies>` of your Maven project (with a `provided` scope 
 to avoid the dependency to be added to your application). In addition, the plugin configuration element
-`<overridden-server-artifacts>` must contain the artifacts. For example, the version 3.0.0 of `io.undertow:undertow-core` will 
+`<overridden-server-artifacts>` must contain the artifacts.
+
+In order to narrow artifact upgrade inside a Galleon feature-pack, the `<FeaturePack>` configuration element is evolved 
+with an `<overridden-artifacts>` set that contains the artifacts (JBoss Modules module 
+artifacts only) that are in use for the upgrade. These artifacts are upgraded only in the feature-pack that define them. 
+A `<Feature-Pack>` element can be added to the pom.xml as a dependency only. A dependency feature-pack 
+is used to override artifacts present in a dependency feature-pack.
+Use the `<dependency>true</dependency>` element to create a dependency feature-pack .
+
+For example, the version 3.0.0 of `io.undertow:undertow-core` will 
 replace the version referenced in the WildFly Galleon feature-pack used to build the bootable JAR:
 
 [source,xml]
@@ -541,15 +550,21 @@ Some notes:
 ** The JBoss module runtime jar (jboss-modules.jar file).
 ** All jar artifacts referenced from JBoss Modules modules.
 
-* If an overridden artifact is no present in the dependencies, then a failure occurs during build.
+* If an overridden artifact is not present in the dependencies, then a failure occurs during build.
 
 * An artifact upgraded to the same version as the one referenced in the Galleon feature-pack is not upgraded. In this case a warning is displayed during build.
 
 * It is possible to downgrade an artifact to an older version. In this case a warning is displayed during build.
 
-* An artifact is referenced in the `overridden-artifacts` by GroupId, Artifactid and optionally Classifier. Version is being retrieved from the Maven dependencies. 
+* An artifact is referenced in the `overridden-server-artifacts` by GroupId, Artifactid and optionally Classifier. Version is being retrieved from the Maven dependencies. 
 
-* An artifact presents in the `overridden-artifacts` list must be unique. Any duplicate will make the packaging to fail.
+* An artifact presents in the `overridden-server-artifacts` list must be unique. Any duplicate will make the packaging to fail.
+
+* An artifact is referenced in the `<FeaturePack>` `overridden-artifacts` by GroupId, ArtifactId, optionally Classifier and optionally Version. 
+Version is being retrieved from the Maven dependencies if not set. Being able to set the version allows to have 
+multiple artifacts with the same GA to be upgraded to different versions according to the feature-pack that contain them.
+
+* An overridden artifact presents in the `<FeaturePack>` `overridden-artifacts` must be unique. Any duplicate will make the packaging to fail.
 
 * Adding an overridden artifact that is not part of the provisioned server artifacts will lead to a failure during build.
 

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/FeaturePack.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/FeaturePack.java
@@ -44,11 +44,22 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
 
     private String includedDefaultConfig;
 
+    private boolean dependency;
+
     private Boolean inheritPackages = false;
     private List<String> excludedPackages = Collections.emptyList();
     private List<String> includedPackages = Collections.emptyList();
+    private List<OverriddenArtifact> overriddenArtifacts = Collections.emptyList();
 
     private Path path;
+
+    public boolean isDependency() {
+        return dependency;
+    }
+
+    public void setDependency(boolean dependency) {
+        this.dependency = dependency;
+    }
 
     @Override
     public String getGroupId() {
@@ -151,6 +162,14 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
         this.includedPackages = includedPackages;
     }
 
+    public List<OverriddenArtifact> getOverridenArtifacts() {
+        return overriddenArtifacts;
+    }
+
+    public void setOverridenArtifacts(List<OverriddenArtifact> overriddenArtifacts) {
+        this.overriddenArtifacts = overriddenArtifacts;
+    }
+
     public void setPath(File path) {
         assertPathLocation();
         this.path = path.toPath().normalize();
@@ -203,6 +222,10 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
         if (includedDefaultConfig != null) {
             buf.append(" included-default-config=");
             buf.append(includedDefaultConfig);
+        }
+        if (dependency) {
+            buf.append(" dependency=");
+            buf.append(dependency);
         }
         return buf.append('}').toString();
     }

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactProducerFPLTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactProducerFPLTestCase.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.wildfly.plugins.bootablejar.maven.common.OverriddenArtifact;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author jdenise
+ */
+// Need WF 23.x that supports per feature-pack upgrade.
+@Ignore
+public class UpgradeArtifactProducerFPLTestCase extends AbstractBootableJarMojoTestCase {
+
+    public UpgradeArtifactProducerFPLTestCase() {
+        super("upgrade-artifact-producer-fpl-pom.xml", true, null);
+    }
+
+    @Test
+    public void testUpgrade() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        MavenProjectArtifactVersions artifacts = MavenProjectArtifactVersions.getInstance(mojo.project);
+        // Upgrade wildfly-ee-galleon-pack and undertow-core. GLoba undertow-core is hidden by specific upgrade
+        // on wildfly-ee-galleon-pack.
+        Assert.assertEquals(2, mojo.overriddenServerArtifacts.size());
+        String hiddenUndertowVersion = null;
+        String wildflyeeVersion = null;
+        boolean seenArtifact = false;
+        boolean seenFeaturePack = false;
+        for (OverriddenArtifact oa : mojo.overriddenServerArtifacts) {
+            Artifact a = null;
+            if ("io.undertow".equals(oa.getGroupId())) {
+                a = artifacts.getArtifact(oa);
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenArtifact = true;
+                hiddenUndertowVersion = a.getVersion();
+            } else {
+                a = artifacts.getFeaturePackArtifact(oa.getGroupId(), oa.getArtifactId(), oa.getClassifier());
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenFeaturePack = true;
+                wildflyeeVersion = a.getVersion();
+            }
+            Assert.assertNotNull(a);
+            Assert.assertNotNull(a.getVersion());
+            Assert.assertEquals(oa.getGroupId(), a.getGroupId());
+            Assert.assertEquals(oa.getArtifactId(), a.getArtifactId());
+        }
+        Assert.assertTrue(seenArtifact && seenFeaturePack);
+
+        // We have an older release of undertow-core in wildfly-ee-galleon-pack in the pom.xml
+        Assert.assertEquals(1, mojo.featurePacks.get(0).getOverridenArtifacts().size());
+
+        OverriddenArtifact oartifact = mojo.featurePacks.get(0).getOverridenArtifacts().get(0);
+        Artifact a = artifacts.getArtifact(oartifact);
+        Assert.assertNotNull(oartifact.getGroupId() + ":" + oartifact.getArtifactId(), a);
+        // Version is present directly in overridden artifact, it hides the global one.
+        String undertowVersion = oartifact.getVersion();
+        mojo.recordState = true;
+        mojo.execute();
+        final Path dir = getTestDir();
+        String[] layers = {"jaxrs-server"};
+        Path unzippedJar = checkAndGetWildFlyHome(dir, true, true, layers, null);
+        try {
+            Path modulesDir = unzippedJar.resolve("modules").resolve("system").resolve("layers").resolve("base");
+            Path undertow = modulesDir.resolve("io").resolve("undertow").resolve("core").resolve("main").resolve("undertow-core-" + undertowVersion + ".jar");
+            Assert.assertTrue(undertow.toString(), Files.exists(undertow));
+            Path ee = modulesDir.resolve("org").resolve("jboss").resolve("as").resolve("ee").resolve("main").resolve("wildfly-ee-" + wildflyeeVersion + ".jar");
+            Assert.assertTrue(ee.toString(), Files.exists(ee));
+        } finally {
+            BuildBootableJarMojo.deleteDir(unzippedJar);
+        }
+        checkJar(dir, true, true, layers, null);
+        checkDeployment(dir, true);
+    }
+
+    @Test
+    public void testInvalidUpgrades() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        Assert.assertEquals(1, mojo.featurePacks.get(0).getOverridenArtifacts().size());
+        List<OverriddenArtifact> orig = new ArrayList<>();
+        orig.addAll(mojo.featurePacks.get(0).getOverridenArtifacts());
+        mojo.featurePacks.get(0).getOverridenArtifacts().addAll(mojo.featurePacks.get(0).getOverridenArtifacts());
+        try {
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+        mojo.featurePacks.get(0).setOverridenArtifacts(orig);
+        String grpId = orig.get(0).getGroupId();
+        try {
+            orig.get(0).getGroupId();
+            orig.get(0).setGroupId(null);
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+        orig.get(0).setGroupId(grpId);
+        try {
+            orig.get(0).setArtifactId(null);
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+
+    }
+}

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactProducerTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactProducerTestCase.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.wildfly.plugins.bootablejar.maven.common.OverriddenArtifact;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author jdenise
+ */
+
+// Need WF 23.x that supports per feature-pack upgrade.
+@Ignore
+public class UpgradeArtifactProducerTestCase extends AbstractBootableJarMojoTestCase {
+
+    public UpgradeArtifactProducerTestCase() {
+        super("upgrade-artifact-producer-pom.xml", true, null);
+    }
+
+    @Test
+    public void testUpgrade() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        MavenProjectArtifactVersions artifacts = MavenProjectArtifactVersions.getInstance(mojo.project);
+        // Upgrade wildfly-ee-galleon-pack and undertow-core. GLoba undertow-core is hidden by specific upgrade
+        // on wildfly-ee-galleon-pack.
+        Assert.assertEquals(2, mojo.overriddenServerArtifacts.size());
+        String hiddenUndertowVersion = null;
+        String wildflyeeVersion = null;
+        boolean seenArtifact = false;
+        boolean seenFeaturePack = false;
+        for (OverriddenArtifact oa : mojo.overriddenServerArtifacts) {
+            Artifact a = null;
+            if ("io.undertow".equals(oa.getGroupId())) {
+                a = artifacts.getArtifact(oa);
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenArtifact = true;
+                hiddenUndertowVersion = a.getVersion();
+            } else {
+                a = artifacts.getFeaturePackArtifact(oa.getGroupId(), oa.getArtifactId(), oa.getClassifier());
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenFeaturePack = true;
+                wildflyeeVersion = a.getVersion();
+            }
+            Assert.assertNotNull(a);
+            Assert.assertNotNull(a.getVersion());
+            Assert.assertEquals(oa.getGroupId(), a.getGroupId());
+            Assert.assertEquals(oa.getArtifactId(), a.getArtifactId());
+        }
+        Assert.assertTrue(seenArtifact && seenFeaturePack);
+
+        // We have an older release of undertow-core in wildfly-ee-galleon-pack in the pom.xml
+        Assert.assertEquals(1, mojo.featurePacks.get(0).getOverridenArtifacts().size());
+
+        OverriddenArtifact oartifact = mojo.featurePacks.get(0).getOverridenArtifacts().get(0);
+        Artifact a = artifacts.getArtifact(oartifact);
+        Assert.assertNotNull(oartifact.getGroupId() + ":" + oartifact.getArtifactId(), a);
+        // Version is present directly in overridden artifact, it hides the global one.
+        String undertowVersion = oartifact.getVersion();
+        mojo.recordState = true;
+        mojo.execute();
+        final Path dir = getTestDir();
+        String[] layers = {"jaxrs-server"};
+        Path unzippedJar = checkAndGetWildFlyHome(dir, true, true, layers, null);
+        try {
+            Path modulesDir = unzippedJar.resolve("modules").resolve("system").resolve("layers").resolve("base");
+            Path undertow = modulesDir.resolve("io").resolve("undertow").resolve("core").resolve("main").resolve("undertow-core-" + undertowVersion + ".jar");
+            Assert.assertTrue(undertow.toString(), Files.exists(undertow));
+            Path ee = modulesDir.resolve("org").resolve("jboss").resolve("as").resolve("ee").resolve("main").resolve("wildfly-ee-" + wildflyeeVersion + ".jar");
+            Assert.assertTrue(ee.toString(), Files.exists(ee));
+        } finally {
+            BuildBootableJarMojo.deleteDir(unzippedJar);
+        }
+        checkJar(dir, true, true, layers, null);
+        checkDeployment(dir, true);
+    }
+
+    @Test
+    public void testInvalidUpgrades() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        Assert.assertEquals(1, mojo.featurePacks.get(0).getOverridenArtifacts().size());
+        List<OverriddenArtifact> orig = new ArrayList<>();
+        orig.addAll(mojo.featurePacks.get(0).getOverridenArtifacts());
+        mojo.featurePacks.get(0).getOverridenArtifacts().addAll(mojo.featurePacks.get(0).getOverridenArtifacts());
+        try {
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+        mojo.featurePacks.get(0).setOverridenArtifacts(orig);
+        String grpId = orig.get(0).getGroupId();
+        try {
+            orig.get(0).getGroupId();
+            orig.get(0).setGroupId(null);
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+        orig.get(0).setGroupId(grpId);
+        try {
+            orig.get(0).setArtifactId(null);
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+        }
+
+    }
+}

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactUnknownArtifactTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactUnknownArtifactTestCase.java
@@ -37,7 +37,7 @@ public class UpgradeArtifactUnknownArtifactTestCase extends AbstractBootableJarM
             mojo.execute();
             throw new Exception("Should have failed");
         } catch (MojoExecutionException ex) {
-            Assert.assertTrue(ex.toString().contains("Overridden artifact jakarta.platform:jakarta.jakartaee-api not know in provisioned feature-packs"));
+            Assert.assertTrue(ex.toString().contains("Overridden artifact jakarta.platform:jakarta.jakartaee-api not known in provisioned feature-packs"));
             // XXX OK, expected
         }
     }

--- a/tests/src/test/resources/poms/upgrade-artifact-producer-fpl-pom.xml
+++ b/tests/src/test/resources/poms/upgrade-artifact-producer-fpl-pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test2</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly bootable jar Example for tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>2.2.2.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-galleon-pack</artifactId>
+            <version>WF_VERSION</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>WF_EE_VERSION</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>wildfly-ee@maven(org.jboss.universe:community-universe)#WF_EE_VERSION</location>
+                            <dependency>true</dependency>
+                            <overridden-artifacts>
+                                <!-- undertow core -->
+                                <artifact>
+                                    <groupId>io.undertow</groupId>
+                                    <artifactId>undertow-core</artifactId>
+                                    <version>2.2.1.Final</version>
+                                </artifact>
+                            </overridden-artifacts>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>TEST_REPLACE</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>jaxrs-server</layer>
+                    </layers>
+                    <overridden-server-artifacts>
+                        <!-- undertow core, this one is hidden by more specific one in wildfly-ee-galleon-pack -->
+                        <artifact>
+                            <groupId>io.undertow</groupId>
+                            <artifactId>undertow-core</artifactId>
+                        </artifact>
+                        <artifact>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                        </artifact>
+                    </overridden-server-artifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/src/test/resources/poms/upgrade-artifact-producer-pom.xml
+++ b/tests/src/test/resources/poms/upgrade-artifact-producer-pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test2</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly bootable jar Example for tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>2.2.2.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-galleon-pack</artifactId>
+            <version>WF_VERSION</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>WF_EE_VERSION</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                            <dependency>true</dependency>
+                            <overridden-artifacts>
+                                <!-- undertow core -->
+                                <artifact>
+                                    <groupId>io.undertow</groupId>
+                                    <artifactId>undertow-core</artifactId>
+                                    <version>2.2.1.Final</version>
+                                </artifact>
+                            </overridden-artifacts>
+                        </feature-pack>
+                        <feature-pack>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-galleon-pack</artifactId>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>jaxrs-server</layer>
+                    </layers>
+                    <overridden-server-artifacts>
+                        <!-- undertow core, this one is hidden by more specific one in wildfly-ee-galleon-pack -->
+                        <artifact>
+                            <groupId>io.undertow</groupId>
+                            <artifactId>undertow-core</artifactId>
+                        </artifact>
+                        <artifact>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                        </artifact>
+                    </overridden-server-artifacts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
* Ability to define overridden-artifacts for a given feature-pack.
* Can declare a feature-pack to be a "dependency". Only used to bring overridden-artifacts during provisioning.
* Generated XML structured with modules grouped per feature-packs.
* Added testcase.
* Updated doc.
