### PR TITLE
Issue #236, Add Wildfly-preview (Jakarta EE 9) tests and example

### DIFF
--- a/examples/jkube/README.md
+++ b/examples/jkube/README.md
@@ -12,3 +12,12 @@ The following command will create and deploy the Bootable JAR on OpenShift:
 `mvn oc:deploy`
 
 Make sure you are logged in to your OpenShift Cluster before you try build/deploy
+
+Jakarta EE9, JKube build and deployment for OpenShift
+========================================
+
+The following command will create and deploy the Bootable JAR built using the `wildfly-preview` galleon feature-pack on OpenShift:
+
+`mvn oc:deploy -Pjakarta-ee9`
+
+Make sure you are logged in to your OpenShift Cluster before you try build/deploy

--- a/examples/jkube/pom.xml
+++ b/examples/jkube/pom.xml
@@ -75,4 +75,21 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>jakarta-ee9</id>
+            <build>
+                <finalName>${project.artifactId}</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>   
+                        <configuration >
+                            <feature-pack-location>wildfly-preview@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,8 @@
     <test.patch.version>${version.wildfly}</test.patch.version>
     <wildfly.artifactId>wildfly-galleon-pack</wildfly.artifactId>
     <wildfly.groupId>org.wildfly</wildfly.groupId>
-    
+    <wildfly-preview.artifactId>wildfly-preview-feature-pack</wildfly-preview.artifactId>
+    <wildfly-preview-build-repo-phase>process-test-resources</wildfly-preview-build-repo-phase>
     <surefire.redirect.to.file>true</surefire.redirect.to.file>
   </properties>
 
@@ -362,6 +363,7 @@
             <test.fpl>${wildfly.groupId}:${wildfly.artifactId}:${version.wildfly}</test.fpl>
             <test.patch.product>JBoss EAP</test.patch.product>
             <test.patch.version>7.4.0.GA</test.patch.version>
+            <wildfly-preview-build-repo-phase>none</wildfly-preview-build-repo-phase>
           </properties>
       </profile>
   </profiles>

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractConfiguredMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractConfiguredMojoTestCase.java
@@ -30,6 +30,7 @@ import org.apache.maven.execution.MavenExecutionRequestPopulator;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
@@ -37,6 +38,8 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class to construct a properly configured MOJO.
@@ -105,7 +108,90 @@ public abstract class AbstractConfiguredMojoTestCase extends AbstractMojoTestCas
 
 
         Mojo mojo = lookupConfiguredMojo(project, goal);
+        // We need to set a logger, the SystemStreamLog is incompatible with Galleon.
+        // There is an interface implementation mismatch that leads to NPE (exception is not checked for null).
+        Logger log = LoggerFactory.getLogger("bootable.jar.test");
+        mojo.setLog(new Log(){
+            @Override
+            public boolean isDebugEnabled() {
+                return log.isDebugEnabled();
+            }
 
+            @Override
+            public void debug(CharSequence cs) {
+                log.debug(cs == null ? null : String.valueOf(cs));
+            }
+
+            @Override
+            public void debug(CharSequence cs, Throwable thrwbl) {
+                log.debug(cs == null ? null : String.valueOf(cs), thrwbl);
+            }
+
+            @Override
+            public void debug(Throwable thrwbl) {
+                log.debug(null, thrwbl);
+            }
+
+            @Override
+            public boolean isInfoEnabled() {
+                return log.isInfoEnabled();
+            }
+
+            @Override
+            public void info(CharSequence cs) {
+                log.info(cs == null ? null : String.valueOf(cs));
+            }
+
+            @Override
+            public void info(CharSequence cs, Throwable thrwbl) {
+                log.info(cs == null ? null : String.valueOf(cs), thrwbl);
+            }
+
+            @Override
+            public void info(Throwable thrwbl) {
+                log.info(null, thrwbl);
+            }
+
+            @Override
+            public boolean isWarnEnabled() {
+                return log.isWarnEnabled();
+            }
+
+            @Override
+            public void warn(CharSequence cs) {
+                log.warn(cs == null ? null : String.valueOf(cs));
+            }
+
+            @Override
+            public void warn(CharSequence cs, Throwable thrwbl) {
+                log.warn(cs == null ? null : String.valueOf(cs), thrwbl);
+            }
+
+            @Override
+            public void warn(Throwable thrwbl) {
+                log.warn(null, thrwbl);
+            }
+
+            @Override
+            public boolean isErrorEnabled() {
+                return log.isErrorEnabled();
+            }
+
+            @Override
+            public void error(CharSequence cs) {
+                log.error(cs == null ? null : String.valueOf(cs));
+            }
+
+            @Override
+            public void error(CharSequence cs, Throwable thrwbl) {
+                log.error(cs == null ? null : String.valueOf(cs), thrwbl);
+            }
+
+            @Override
+            public void error(Throwable thrwbl) {
+                log.error(null, thrwbl);
+            }
+        });
         // For some reasons, the configuration item gets ignored in lookupConfiguredMojo
         // explicitly configure it
         configureMojo(mojo, ARTIFACTID, pom);

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactEE9TransformTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactEE9TransformTestCase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.artifact.Artifact;
+import org.wildfly.plugins.bootablejar.maven.common.OverriddenArtifact;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * @author jdenise
+ */
+public class UpgradeArtifactEE9TransformTestCase extends AbstractBootableJarMojoTestCase {
+
+    public UpgradeArtifactEE9TransformTestCase() {
+        super("upgrade-artifact-ee9-pom.xml", true, null);
+    }
+
+    @Test
+    public void testUpgrade() throws Exception {
+        Assume.assumeFalse("Not stupported on XP", isXP());
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        mojo.getLog().info("COUCOU");
+        MavenProjectArtifactVersions artifacts = MavenProjectArtifactVersions.getInstance(mojo.project);
+        // We have an older release of undertow-core and wildfly-ee-galleon-pack in the pom.xml
+        Assert.assertEquals(3, mojo.overriddenServerArtifacts.size());
+        String undertowVersion = null;
+        String wildflyeeVersion = null;
+        String restEasySpringVersion = null;
+        boolean seenUndertow = false;
+        boolean seenRestEasy = false;
+        boolean seenWildFlyEE = false;
+        for (OverriddenArtifact oa : mojo.overriddenServerArtifacts) {
+            Artifact a = null;
+            if ("io.undertow".equals(oa.getGroupId())) {
+                a = artifacts.getArtifact(oa);
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenUndertow = true;
+                undertowVersion = a.getVersion();
+            } else if ("org.jboss.resteasy".equals(oa.getGroupId())) {
+                a = artifacts.getArtifact(oa);
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenRestEasy = true;
+                restEasySpringVersion = a.getVersion();
+            } else {
+                a = artifacts.getArtifact(oa);
+                Assert.assertNotNull(oa.getGroupId() + ":" + oa.getArtifactId(), a);
+                seenWildFlyEE = true;
+                wildflyeeVersion = a.getVersion();
+            }
+            Assert.assertNotNull(a);
+            Assert.assertNotNull(a.getVersion());
+            Assert.assertEquals(oa.getGroupId(), a.getGroupId());
+            Assert.assertEquals(oa.getArtifactId(), a.getArtifactId());
+        }
+        Assert.assertTrue(seenUndertow && seenWildFlyEE && seenRestEasy);
+        mojo.recordState = true;
+        mojo.execute();
+        final Path dir = getTestDir();
+        String[] layers = {"jaxrs", "management"};
+        Path unzippedJar = checkAndGetWildFlyHome(dir, true, true, layers, null);
+        try {
+            Path modulesDir = unzippedJar.resolve("modules").resolve("system").resolve("layers").resolve("base");
+            Path undertow = modulesDir.resolve("io").resolve("undertow").resolve("core").resolve("main").resolve("undertow-core-" + undertowVersion + ".jar");
+            Assert.assertTrue(undertow.toString(), Files.exists(undertow));
+            Path ee = modulesDir.resolve("org").resolve("jboss").resolve("as").resolve("ee").resolve("main").resolve("wildfly-ee-" + wildflyeeVersion + "-ee9.jar");
+            Assert.assertTrue(ee.toString(), Files.exists(ee));
+            Path resteasy = modulesDir.resolve("org").resolve("jboss").resolve("resteasy").resolve("resteasy-spring").resolve("main").
+                    resolve("bundled").resolve("resteasy-spring-jar").resolve("resteasy-spring-" + restEasySpringVersion + "ee9.jar");
+            Assert.assertTrue(ee.toString(), Files.exists(ee));
+        } finally {
+            BuildBootableJarMojo.deleteDir(unzippedJar);
+        }
+        checkJar(dir, true, true, layers, null);
+        checkDeployment(dir, true);
+    }
+}

--- a/tests/src/test/resources/poms/upgrade-artifact-ee9-pom.xml
+++ b/tests/src/test/resources/poms/upgrade-artifact-ee9-pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test2</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly bootable jar Example for tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>2.2.2.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>WF_GROUPID</groupId>
+            <artifactId>wildfly-preview-feature-pack</artifactId>
+            <version>WF_VERSION</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>WF_GROUPID</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <version>WF_EE_VERSION</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-spring</artifactId>
+            <scope>provided</scope>
+            <version>3.15.0.Final</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>WF_GROUPID</groupId>
+                            <artifactId>wildfly-preview-feature-pack</artifactId>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>jaxrs</layer>
+                        <layer>management</layer>
+                    </layers>
+                    <overridden-server-artifacts>
+                        <!-- undertow core -->
+                        <artifact>
+                            <groupId>io.undertow</groupId>
+                            <artifactId>undertow-core</artifactId>
+                        </artifact>
+                        <artifact>
+                            <groupId>WF_GROUPID</groupId>
+                            <artifactId>wildfly-ee</artifactId>
+                        </artifact>
+                        <artifact>
+                            <groupId>org.jboss.resteasy</groupId>
+                            <artifactId>resteasy-spring</artifactId>
+                        </artifact>
+                    </overridden-server-artifacts>
+                </configuration>
+                
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
* New test and example based on Wildfly Jakarta EE9 feature-pack.
* Discovered that the logger present in a mojo built by AbstractMojoTest has a logger incompatible with Galleon. I am setting a logger in the test.