### PR TITLE
Fix for Issue #245, microprofile-health vs health for cloud

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -315,7 +315,7 @@ Adding the ```<cloud/>``` element to the plugin configuration automatically enab
 The sever configuration is updated in order to properly operate in a cloud environment:
 
 * If no Galleon layers are provisioned, the provisioned configuration is ```standalone-microprofile-ha.xml``` instead of ```standalone-microprofile.xml```.
-* The ```microprofile-health``` and ```core-tools``` (that contains WildFly CLI) Galleon layers are provisioned. They are required for the  OpenShift probes and WildFly OpenShift Operator to properly operate.
+* The ```microprofile-health``` (or ```health``` layer if the WildFly Galleon feature-pack doesn't define ```microprofile-health``` layer) and ```core-tools``` (that contains WildFly CLI) Galleon layers are provisioned. They are required for the  OpenShift probes and WildFly OpenShift Operator to properly operate.
 * The public and private inet addresses are bound to the value of the ```HOSTNAME``` environment variable if defined (defined in OpenShift PODS).
 * The management inet address is bound to the 0.0.0.0 inet address allowing for local (required by WildFly CLI) and remote access (required by OpenShift readiness and liveness probes).
 * The http and https socket-bindings are bound to 0.0.0.0 inet address.

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/cloud/CloudConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.jboss.galleon.util.ZipUtils;
@@ -111,9 +112,14 @@ public class CloudConfig {
         }
     }
 
-    public Set<String> getExtraLayers(BuildBootableJarMojo mojo) {
+    public Set<String> getExtraLayers(BuildBootableJarMojo mojo, String healthLayer, Log log) {
         Set<String> set = new HashSet<>();
-        set.add("microprofile-health");
+        if (healthLayer == null) {
+            log.warn("No health layer found in feature-packs, health endpoint will be not available.");
+        } else {
+            set.add(healthLayer);
+            log.debug("Adding health layer " + healthLayer);
+        }
         set.add("core-tools");
         return set;
     }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/Utils.java
@@ -17,22 +17,60 @@
 package org.wildfly.plugins.bootablejar.maven.common;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.ConfigId;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.layout.FeaturePackLayout;
+import org.jboss.galleon.layout.ProvisioningLayout;
+import org.jboss.galleon.universe.FeaturePackLocation;
 import org.wildfly.plugins.bootablejar.maven.goals.BuildBootableJarMojo;
 
 /**
  * @author jdenise
  */
 public class Utils {
+
+    private static final String HEALTH = "health";
+    private static final String MP_HEALTH = "microprofile-health";
+
+    public static class ProvisioningSpecifics {
+
+        private final boolean isMicroprofile;
+        private final String healthLayer;
+
+        ProvisioningSpecifics(Set<String> allLayers) {
+            if (allLayers.contains(MP_HEALTH)) {
+                healthLayer = MP_HEALTH;
+                isMicroprofile = true;
+            } else {
+                if (allLayers.contains(HEALTH)) {
+                    healthLayer = HEALTH;
+                } else {
+                    healthLayer = null;
+                }
+                isMicroprofile = false;
+            }
+        }
+
+        public String getHealthLayer() {
+            return healthLayer;
+        }
+    }
 
     public static final String NO_COLOR_OPTION="-Dorg.jboss.logmanager.nocolor=true";
 
@@ -87,4 +125,40 @@ public class Utils {
         return args;
     }
 
+    public static ProvisioningSpecifics getSpecifics(List<FeaturePack> fps, ProvisioningManager pm) throws ProvisioningException, IOException {
+        return new ProvisioningSpecifics(getAllLayers(fps, pm));
+    }
+
+    private static Set<String> getAllLayers(List<FeaturePack> fps, ProvisioningManager pm) throws ProvisioningException, IOException {
+        Set<String> allLayers = new HashSet<>();
+        for (FeaturePack fp : fps) {
+            final FeaturePackLocation fpl;
+            if (fp.getNormalizedPath() != null) {
+                fpl = pm.getLayoutFactory().addLocal(fp.getNormalizedPath(), false);
+            } else if (fp.getGroupId() != null && fp.getArtifactId() != null) {
+                String coords = fp.getMavenCoords();
+                fpl = FeaturePackLocation.fromString(coords);
+            } else {
+                fpl = FeaturePackLocation.fromString(fp.getLocation());
+            }
+            ProvisioningConfig pConfig = ProvisioningConfig.builder().
+                    addFeaturePackDep(FeaturePackConfig.builder(fpl).build()).build();
+            try (ProvisioningLayout<FeaturePackLayout> layout = pm.
+                    getLayoutFactory().newConfigLayout(pConfig)) {
+                allLayers.addAll(getAllLayers(layout));
+            }
+        }
+        return allLayers;
+    }
+
+    private static Set<String> getAllLayers(ProvisioningLayout<FeaturePackLayout> pLayout)
+            throws ProvisioningException, IOException {
+        Set<String> layers = new HashSet<>();
+        for (FeaturePackLayout fp : pLayout.getOrderedFeaturePacks()) {
+            for (ConfigId layer : fp.loadLayers()) {
+                layers.add(layer.getName());
+            }
+        }
+        return layers;
+    }
 }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
@@ -103,6 +103,8 @@ import org.wildfly.plugins.bootablejar.maven.common.FeaturePack;
 import org.wildfly.plugins.bootablejar.maven.common.LegacyPatchCleaner;
 import org.wildfly.plugins.bootablejar.maven.common.MavenRepositoriesEnricher;
 import org.wildfly.plugins.bootablejar.maven.common.OverriddenArtifact;
+import org.wildfly.plugins.bootablejar.maven.common.Utils;
+import org.wildfly.plugins.bootablejar.maven.common.Utils.ProvisioningSpecifics;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -110,7 +112,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  *
  * @author jfdenise
  */
-public class AbstractBuildBootableJarMojo extends AbstractMojo {
+public abstract class AbstractBuildBootableJarMojo extends AbstractMojo {
 
     public static final String BOOTABLE_SUFFIX = "bootable";
     public static final String JAR = "jar";
@@ -1042,24 +1044,6 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
         }
     }
 
-    /**
-     * Galleon layers based config that uses the FPL.
-     */
-    private class LayersFPLConfig extends AbstractLayersConfig {
-
-        private LayersFPLConfig() throws ProvisioningDescriptionException, ProvisioningException {
-        }
-        @Override
-        public ProvisioningConfig.Builder buildState() throws ProvisioningException {
-            ProvisioningConfig.Builder state = ProvisioningConfig.builder();
-            FeaturePackConfig.Builder builder = FeaturePackConfig.
-                    builder(FeaturePackLocation.fromString(featurePackLocation)).
-                    setInheritPackages(false).setInheritConfigs(false);
-            FeaturePackConfig dependency = builder.build();
-            state.addFeaturePackDep(dependency);
-            return state;
-        }
-    }
 
     /**
      * Galleon layers based config that uses the set of feature-packs.
@@ -1109,31 +1093,6 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
     }
 
     /**
-     * A config based on a default config retrieved in the FPL.
-     */
-    private class DefaultFPLConfig extends AbstractDefaultConfig {
-        private final ConfigId configId;
-
-        private DefaultFPLConfig(ConfigId configId) throws ProvisioningException {
-            super(configId);
-            this.configId = configId;
-        }
-
-        @Override
-        protected ProvisioningConfig.Builder buildState() throws ProvisioningException {
-            ProvisioningConfig.Builder state = ProvisioningConfig.builder();
-            FeaturePackConfig.Builder builder = FeaturePackConfig.
-                    builder(FeaturePackLocation.fromString(featurePackLocation)).
-                    setInheritPackages(false).setInheritConfigs(false).includeDefaultConfig(configId.getModel(),
-                    configId.getName());
-            FeaturePackConfig dependency = builder.build();
-            state.addFeaturePackDep(dependency);
-            return state;
-        }
-
-    }
-
-    /**
      * A config based on the set of feature-packs. Default config is explicitly
      * included or is the default.
      */
@@ -1154,26 +1113,18 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
 
     }
 
-    private GalleonConfig buildGalleonConfig(ProvisioningManager pm) throws ProvisioningException, MojoExecutionException {
-        boolean isLayerBasedConfig = !layers.isEmpty();
-        boolean hasFeaturePack = featurePackLocation != null || !featurePacks.isEmpty();
-        boolean hasProvisioningFile = Files.exists(getProvisioningFile());
-        if (!hasFeaturePack && !hasProvisioningFile) {
-            throw new ProvisioningException("No valid provisioning configuration, "
-                    + "you must set a feature-pack-location, a list of feature-packs or use a provisioning.xml file");
-        }
-
+    private void normalizeFeaturePackList() throws MojoExecutionException {
         if (featurePackLocation != null && !featurePacks.isEmpty()) {
             throw new MojoExecutionException("feature-pack-location can't be used with a list of feature-packs");
-        }
-
-        if (hasFeaturePack && hasProvisioningFile) {
-            getLog().warn("Feature packs defined in pom.xml override provisioning file located in " + getProvisioningFile());
         }
 
         // Retrieve versions from Maven in case versions not set.
         if (featurePackLocation != null) {
             featurePackLocation = MavenUpgrade.locationWithVersion(featurePackLocation, artifactVersions);
+            featurePacks = new ArrayList<>();
+            FeaturePack fp = new FeaturePack();
+            fp.setLocation(featurePackLocation);
+            featurePacks.add(fp);
         } else {
             for (FeaturePack fp : featurePacks) {
                 if (fp.getLocation() != null) {
@@ -1192,26 +1143,29 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
                 }
             }
         }
+    }
+
+    private GalleonConfig buildGalleonConfig(ProvisioningManager pm) throws ProvisioningException, MojoExecutionException {
+        boolean isLayerBasedConfig = !layers.isEmpty();
+        boolean hasFeaturePack = !featurePacks.isEmpty();
+        boolean hasProvisioningFile = Files.exists(getProvisioningFile());
+        if (!hasFeaturePack && !hasProvisioningFile) {
+            throw new ProvisioningException("No valid provisioning configuration, "
+                    + "you must set a feature-pack-location, a list of feature-packs or use a provisioning.xml file");
+        }
+
+        if (hasFeaturePack && hasProvisioningFile) {
+            getLog().warn("Feature packs defined in pom.xml override provisioning file located in " + getProvisioningFile());
+        }
 
         if (isLayerBasedConfig) {
             if (!hasFeaturePack) {
                 throw new ProvisioningException("No server feature-pack location to provision layers, you must set a feature-pack-location");
             }
-            if (featurePackLocation == null) {
-                getLog().info("Provisioning server using feature-packs");
-                return buildFeaturePacksConfig(pm, true);
-            } else {
-                getLog().info("Provisioning server configuration based on the set of configured layers");
-                return new LayersFPLConfig();
-            }
+            return buildFeaturePacksConfig(pm, true);
         }
 
-        if (featurePackLocation != null) {
-            ConfigId defaultConfig = getDefaultConfig();
-            getLog().info("Provisioning server configuration based on the " + defaultConfig.getName() + " default configuration");
-            return new DefaultFPLConfig(defaultConfig);
-        }
-
+        // Based on default config
         if (!featurePacks.isEmpty()) {
             getLog().info("Provisioning server using feature-packs");
             return buildFeaturePacksConfig(pm, isLayerBasedConfig);
@@ -1224,6 +1178,14 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
         throw new ProvisioningException("Invalid Galleon configuration");
     }
 
+    private void willProvision(List<FeaturePack> featurePacks, ProvisioningManager pm)
+            throws MojoExecutionException, ProvisioningException, IOException {
+        ProvisioningSpecifics specifics = Utils.getSpecifics(featurePacks, pm);
+        willProvision(specifics);
+    }
+
+    protected abstract void willProvision(ProvisioningSpecifics specifics) throws MojoExecutionException;
+
     private Artifact provisionServer(Path home, Path outputProvisioningFile, Path workDir) throws ProvisioningException,
             MojoExecutionException, IOException, XMLStreamException {
         try (ProvisioningManager pm = ProvisioningManager.builder().addArtifactResolver(artifactResolver)
@@ -1233,6 +1195,10 @@ public class AbstractBuildBootableJarMojo extends AbstractMojo {
                 .setRecordState(recordState)
                 .build()) {
 
+            // Prior to build the config, sub classes could have to inject content to the config according to the
+            // provisioned FP.
+            normalizeFeaturePackList();
+            willProvision(featurePacks, pm);
             ProvisioningConfig config = buildGalleonConfig(pm).buildConfig();
             IoUtils.recursiveDelete(home);
             getLog().info("Building server based on " + config.getFeaturePackDeps() + " galleon feature-packs");

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.jboss.galleon.config.ConfigId;
+import org.wildfly.plugins.bootablejar.maven.common.Utils.ProvisioningSpecifics;
 
 /**
  * Build a bootable JAR containing application and provisioned server
@@ -57,16 +58,21 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
             getLog().debug(String.format("Skipping run of %s:%s", project.getGroupId(), project.getArtifactId()));
             return;
         }
+        super.execute();
+    }
+
+    @Override
+    protected void willProvision(ProvisioningSpecifics specifics) throws
+            MojoExecutionException {
         if (!isPackageDev()) {
             if (isCloudEnabled()) {
                 getLog().info("Cloud support is enabled");
                 cloud.validate();
-                for (String layer : cloud.getExtraLayers(this)) {
+                for (String layer : cloud.getExtraLayers(this, specifics.getHealthLayer(), getLog())) {
                     addExtraLayer(layer);
                 }
             }
         }
-        super.execute();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,12 @@
 
     <maven.test.skip>false</maven.test.skip>
     <skipTests>${maven.test.skip}</skipTests>
-    
+
+    <test.ee.fpl>wildfly-ee@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.ee.fpl>
     <test.fpl>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.fpl>
     <test.version.wildfly>${version.wildfly}</test.version.wildfly>
     <test.version.wildfly-ee.upgrade>22.0.0.Final</test.version.wildfly-ee.upgrade>
+    <test.patch.ee.product>WildFly EE</test.patch.ee.product>
     <test.patch.product>WildFly Full</test.patch.product>
     <test.patch.version>${version.wildfly}</test.patch.version>
     <wildfly.artifactId>wildfly-galleon-pack</wildfly.artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -157,51 +157,87 @@
                 -->
                 <configuration>
                     <reuseForks>false</reuseForks>
+                    <redirectTestOutputToFile>${surefire.redirect.to.file}</redirectTestOutputToFile>
+                    <systemProperties>
+                        <property>
+                            <name>test.version.wildfly-ee.upgrade</name>
+                            <value>${test.version.wildfly-ee.upgrade}</value>
+                        </property>
+                        <property>
+                            <name>test.version.wildfly</name>
+                            <value>${test.version.wildfly}</value>
+                        </property>
+                        <property>
+                            <name>test.plugin.version</name>
+                            <value>${project.version}</value>
+                        </property>
+                        <property>
+                            <name>test.patch.version</name>
+                            <value>${test.patch.version}</value>
+                        </property>
+                        <property>
+                            <name>jbossas.dist</name>
+                            <value>${jbossas.dist}</value>
+                        </property>
+                        <property>
+                            <name>test.groupid.wildfly</name>
+                            <value>${wildfly.groupId}</value>
+                        </property>
+                    </systemProperties>
                 </configuration>
                 <executions>
-                    <!-- Enable the default tests (which the parent pom turns off for this profile) -->
                     <execution>
                         <id>default-test</id>
                         <goals>
                             <goal>test</goal>
                         </goals>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- run subset of tests with wildfly-ee -->
+                    <execution>
+                        <id>default-test-wildfly-ee</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
                         <phase>test</phase>
                         <configuration>
-                            <systemProperties>
+                            <systemProperties combine.children="append">
+                                <property>
+                                    <name>test.fpl</name>
+                                    <value>${test.ee.fpl}</value>
+                                </property>
+                                <property>
+                                    <name>test.health</name>
+                                    <value>health</value>
+                                </property>
+                            </systemProperties>
+                            <includes>
+                                <include>org/wildfly/plugins/bootablejar/maven/goals/OpenShiftConfigurationTestCase.java</include>
+                                <include>org/wildfly/plugins/bootablejar/maven/goals/ServerModeOpenShiftConfigurationTestCase.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-test-wildfly-full</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <systemProperties combine.children="append">
                                 <property>
                                     <name>test.fpl</name>
                                     <value>${test.fpl}</value>
-                                </property>
-                                <property>
-                                    <name>test.version.wildfly-ee.upgrade</name>
-                                    <value>${test.version.wildfly-ee.upgrade}</value>
-                                </property>
-                                <property>
-                                    <name>test.version.wildfly</name>
-                                    <value>${test.version.wildfly}</value>
-                                </property>
-                                <property>
-                                    <name>test.plugin.version</name>
-                                    <value>${project.version}</value>
-                                </property>
-                                <property>
-                                    <name>test.patch.version</name>
-                                    <value>${test.patch.version}</value>
                                 </property>
                                 <property>
                                     <name>test.patch.product</name>
                                     <value>${test.patch.product}</value>
                                 </property>
                                 <property>
-                                    <name>jbossas.dist</name>
-                                    <value>${jbossas.dist}</value>
-                                </property>
-                                <property>
-                                    <name>test.groupid.wildfly</name>
-                                    <value>${wildfly.groupId}</value>
+                                    <name>test.health</name>
+                                    <value>microprofile-health</value>
                                 </property>
                             </systemProperties>
-                            <redirectTestOutputToFile>${surefire.redirect.to.file}</redirectTestOutputToFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -216,4 +252,80 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <!-- Run all tests with wildfly-ee galleon feature-pack -->
+            <id>wildfly-ee</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-test-wildfly-ee</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-test-wildfly-full</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>all-test-wildfly-ee</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemProperties combine.children="append">
+                                        <property>
+                                            <name>test.fpl</name>
+                                            <value>${test.ee.fpl}</value>
+                                        </property>
+                                        <property>
+                                            <name>test.health</name>
+                                            <value>health</value>
+                                        </property>
+                                        <property>
+                                            <name>test.patch.product</name>
+                                            <value>${test.patch.ee.product}</value>
+                                        </property>
+                                    </systemProperties>
+                                    <excludes>
+                                        <!-- Excluded due to no support for default configuration when provisioning wildfly-ee galleon feature-pack. -->
+                                        <!-- Exclusion will be removed when standalone.xml and standalone-ha.xml are expressed with Galleon layers 
+                                        and the plugin discovers default configurations. -->
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactFPLTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/PatchExistingMiscTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationSecurityManagerTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationWithFPTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationCloudTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationNoLayersTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationWithFPTestCase.java</exclude>
+                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationExcludeLayerTestCase.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -77,6 +77,7 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
     private static final String TEST_REPLACE_WF_VERSION = "WF_VERSION";
     static final String PLUGIN_VERSION_TEST_REPLACE = "PLUGIN_VERSION";
     static final String TEST_FILE = "test-" + AbstractBuildBootableJarMojo.BOOTABLE_SUFFIX + ".jar";
+    static final String HEALTH = System.getProperty("test.health");
     static final String SERVER_DEFAULT_DIR_NAME ="server";
     private final String projectFile;
     private final boolean copyWar;

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/OpenShiftConfigurationTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/OpenShiftConfigurationTestCase.java
@@ -40,7 +40,7 @@ public class OpenShiftConfigurationTestCase extends AbstractBootableJarMojoTestC
         assertEquals("jaxrs", mojo.layers.get(0));
         mojo.recordState = true;
         mojo.execute();
-        String[] layers = {"jaxrs", "microprofile-health", "core-tools"};
+        String[] layers = {"jaxrs", HEALTH, "core-tools"};
         final Path dir = getTestDir();
         checkJar(dir, true, true, layers, null, mojo.recordState);
         checkDeployment(dir, true);

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ServerModeOpenShiftConfigurationTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ServerModeOpenShiftConfigurationTestCase.java
@@ -40,7 +40,7 @@ public class ServerModeOpenShiftConfigurationTestCase extends AbstractBootableJa
         assertEquals("jaxrs", mojo.layers.get(0));
         mojo.recordState = true;
         mojo.execute();
-        String[] layers = {"jaxrs", "microprofile-health", "core-tools"};
+        String[] layers = {"jaxrs", HEALTH, "core-tools"};
         final Path dir = getTestDir();
         checkServer(dir, SERVER_DEFAULT_DIR_NAME, 1, true, layers, null, mojo.recordState);
         checkDeployment(false, dir, true);

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/WebServicesTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/WebServicesTestCase.java
@@ -41,7 +41,7 @@ public class WebServicesTestCase extends AbstractBootableJarMojoTestCase {
         assertEquals("webservices", mojo.layers.get(1));
         mojo.recordState = true;
         mojo.execute();
-        String[] layers = {"datasources-web-server", "webservices", "microprofile-health", "core-tools"};
+        String[] layers = {"datasources-web-server", "webservices", HEALTH, "core-tools"};
         final Path dir = getTestDir();
         checkJar(dir, true, true, layers, null, mojo.recordState,
                 "<wsdl-host>jbossws.undefined.host</wsdl-host>",


### PR DESCRIPTION
* Cloud, health vs microprofile-health Galleon layer according to the feature-pack
* Run few tests with wildfly-ee-galleon-pack to cover cloud case.
* Added wildfly-ee profile to run all tests with wildfly-ee (not run in CI for now). Excluding for now tests that rely on default configurations that can't be run wildfly-ee-galleon-pack until default configurations are defined with Galleon Layers.
* Removed some configuration cases by relying only on the list of featurePacks in all cases.