### PR TITLE
[WFLY-15093] check outputFileName for bootable jar file name

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractDevBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractDevBootableJarMojo.java
@@ -65,7 +65,7 @@ public abstract class AbstractDevBootableJarMojo extends BuildBootableJarMojo {
 
     protected Launcher buildLauncher(boolean redirect) throws MojoExecutionException {
         if (isJarPackaging()) {
-           BootableJarCommandBuilder builder = BootableJarCommandBuilder.of(Utils.getBootableJarPath(null, project, "dev"))
+           BootableJarCommandBuilder builder = BootableJarCommandBuilder.of(Utils.getBootableJarPath(outputFileName, project, "dev"))
                     .addJavaOptions(jvmArguments)
                     .addServerArguments(arguments);
             if (redirect) {


### PR DESCRIPTION
This fixes #263
issue: https://issues.redhat.com/browse/WFLY-15093