### PR TITLE
elytron-oidc-client example

### DIFF
--- a/examples/elytron-oidc-client/README.md
+++ b/examples/elytron-oidc-client/README.md
@@ -1,0 +1,39 @@
+# Elytron OpenID Connect (OIDC) client, WildFly bootable jar example
+
+Starting WildFly 25, we have removed the need for the `org.keycloak:keycloak-adapter-galleon-pack` Galleon feature-pack in order to 
+secure a deployment with OIDC. WildFly offers a native support for OIDC that is highlighted by this example.
+
+We are relying on the `elytron-oidc-client` subsystem that has been introduced in WildFly 25. This subsystem allows to interact with OIDC compatible 
+authorization servers. In this example we are interacting with a Keycloak authorization server.
+
+The WildFly Galleon layer `elytron-oidc-client` brings in the `elytron-oidc-client` subsystem to the server configuration. This layer,
+provisioned with the `web-server` Galleon layer, produces a server containing the features required to run a Servet secured with OIDC. 
+
+In this example we have chosen to embed the security configuration in the deployment. The descriptor file `WEB-INF/oidc.json` contains the configuration 
+required to secure the deployment. This file contains the expression `${org.wildfly.bootable.jar.example.oidc.provider-url}` 
+(a references to the `org.wildfly.bootable.jar.example.oidc.provider-url` system property) for the provider URL value. 
+This allows you to adjust this URL according to your execution context.
+
+NB: In order for the deployment to be identified as "secured with OIDC", the `auth-method` value in `WEB-INF/web.xml` file must be set to `OIDC`.
+
+Initial Steps
+=======
+
+* Download the keycloak server from: `https://www.keycloak.org/download`
+* Start the keycloak server to listen on port 8090: `keycloak/bin/standalone.sh -Djboss.socket.binding.port-offset=10`
+* Log into the keycloak server admin console (you will possibly be asked to create an initial admin user) : `http://127.0.0.1:8090/`
+* Create a Realm named `WildFly`
+* Create a Role named `Users`
+* Create a User named `demo`, password `demo`
+* Assign the role `Users` to the user `demo`
+* Create a Client named `simple-webapp` with Root URL: `http://127.0.0.1:8080/simple-webapp`
+
+Build and run
+========
+
+* To build: `mvn package`
+* To run: `java -jar target/simple-webapp-bootable.jar -Dorg.wildfly.bootable.jar.example.oidc.provider-url="http://localhost:8090/auth/realms/WildFly"`
+* Access the application: `http://127.0.0.1:8080/simple-webapp`
+* Access the secured servlet.
+* Log-in using the `demo` user, `demo` password (that you created in the initial steps).
+* You should see a page containing the Principal ID.

--- a/examples/elytron-oidc-client/pom.xml
+++ b/examples/elytron-oidc-client/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <version>6.0.0.Final-SNAPSHOT</version>
+    </parent>
+    <artifactId>elytron-oidc-client</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly Bootable JAR - Elytron OIDC client</name>
+    <description>An application secured with Elytron oidc client example</description>
+
+     <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>simple-webapp</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>web-server</layer>
+                        <layer>elytron-oidc-client</layer>
+                    </layers>
+                    <context-root>false</context-root>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/examples/elytron-oidc-client/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/examples/elytron-oidc-client/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpMethodConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@WebServlet("/secured")
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Users" }) })
+public class SecuredServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.println("<html>");
+            writer.println("  <head><title>Secured Servlet</title></head>");
+            writer.println("  <body>");
+            writer.println("    <h1>Secured Servlet</h1>");
+            writer.println("    <p>");
+            writer.print(" Current Principal '");
+            Principal user = req.getUserPrincipal();
+            writer.print(user != null ? user.getName() : "NO AUTHENTICATED USER");
+            writer.print("'");
+            writer.println("    </p>");
+            writer.println("  </body>");
+            writer.println("</html>");
+        }
+    }
+
+}

--- a/examples/elytron-oidc-client/src/main/webapp/WEB-INF/oidc.json
+++ b/examples/elytron-oidc-client/src/main/webapp/WEB-INF/oidc.json
@@ -1,0 +1,7 @@
+{
+  "provider-url": "${org.wildfly.bootable.jar.example.oidc.provider-url}",
+  "ssl-required": "external",
+  "client-id": "simple-webapp",
+  "public-client": true,
+  "confidential-port": 0
+}

--- a/examples/elytron-oidc-client/src/main/webapp/WEB-INF/web.xml
+++ b/examples/elytron-oidc-client/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   metadata-complete="false">
+
+    <login-config>
+        <auth-method>OIDC</auth-method>
+    </login-config>
+
+</web-app>

--- a/examples/elytron-oidc-client/src/main/webapp/index.html
+++ b/examples/elytron-oidc-client/src/main/webapp/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h2>Hello World!</h2>
+    <a href="./secured">Access Secured Servlet</a>
+  </body>
+</html>

--- a/examples/keycloak/README.md
+++ b/examples/keycloak/README.md
@@ -1,4 +1,8 @@
-# Keycloak WildFly bootable jar example
+# [DEPRECATED] Keycloak WildFly bootable jar example
+
+The example `../elytron-oidc-client` highlight the supported way to secure a deployment using OpenID Connect (OIDC).
+
+Usage of the Keycloak Galleon feature-pack highlighted in this example is deprecated.
 
 Build a bootable JAR containing an application secured with Keycloak.
 In order to enable keycloak, you must use the Galleon layer `keycloak-client-oidc` that brings in the 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -88,6 +88,7 @@
         <module>authentication</module>
         <module>ejb-in-ear</module>
         <module>ejb-in-war</module>
+        <module>elytron-oidc-client</module>
         <module>gradle-mdb-rar</module>
         <module>hollow-jar</module>
         <module>https</module>


### PR DESCRIPTION
New example to highlight elytron-oidc-client Galleon layer example.
The deployment contains WEB-INF/oidc.json file.
Auth server url is resolved thanks to a System property.

The existing keycloak example is deprecated.
 