### PR TITLE
Adding logic to re-escape backslashes for CLI session properties file values

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/common/Utils.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -154,4 +155,20 @@ public class Utils {
         return modularJvm;
     }
 
+    public static Properties processProperties(Properties rawProps) {
+        final Properties props = new Properties();
+        rawProps.entrySet().stream()
+                .forEach(e -> {
+                    props.setProperty(e.getKey().toString(), escapeBackslashes(e.getValue().toString()));
+                });
+        return props;
+    }
+
+    private static String escapeBackslashes(final String propertyValue) {
+        String finalValue = propertyValue;
+        if (propertyValue.contains("\\")) {
+            finalValue = propertyValue.replace("\\", "\\\\");
+        }
+        return finalValue;
+    }
 }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
@@ -804,10 +804,11 @@ public abstract class AbstractBuildBootableJarMojo extends AbstractMojo {
         if (Files.notExists(filePath)) {
             throw new RuntimeException("Cli properties file " + filePath + " doesn't exist");
         }
-        final Properties props = new Properties();
+        final Properties props, rawProps = new Properties();
         try (InputStreamReader inputStreamReader = new InputStreamReader(new FileInputStream(filePath.toFile()),
                 StandardCharsets.UTF_8)) {
-            props.load(inputStreamReader);
+            rawProps.load(inputStreamReader);
+            props = Utils.processProperties(rawProps);
         } catch (IOException e) {
             throw new Exception(
                     "Failed to load properties from " + propertiesFile + ": " + e.getLocalizedMessage());

--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/common/PropertiesParsingTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/common/PropertiesParsingTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugins.bootablejar.maven.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+/**
+ * Test basic properties manipulation when values are loaded from a file, i.e.: by using {@link Properties#load(Reader)}
+ *
+ * @author <a href="mailto:fburzigo@redhat.com">Fabio Burzigotti</a>
+ */
+public class PropertiesParsingTestCase {
+
+    private static final Properties EXPECTED_WINDOWS_PATH_PROPS = new Properties();
+    // See the "backslashes.properties" file in test/resources
+    private static final String ESCAPED_DOUBLE_QUOTE = "escaped.double.quote";
+    private static final String UNESCAPED_DOUBLE_QUOTE = "unescaped.double.quote";
+    private static final String REGULAR_WINDOWS_PATH = "windows.path.regular";
+    private static final String WINDOWS_PATH_WITH_INTERNAL_SPACE = "windows.path.internal.space";
+    private static final String WINDOWS_PATH_WITH_UPPERCASE_VOLUME = "windows.path.uppercase.volume";
+    private static final String WINDOWS_PATH_WITH_TRAILING_SLASH = "windows.path.trailing.slash";
+    private static final String WINDOWS_PATH_UNESCAPED = "windows.path.unescaped";
+
+    public PropertiesParsingTestCase() {
+        // Double quotes don't need to be escaped, but when done the result would be the same, i.e. output the (").
+        // See Properties.load() Javadoc
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(ESCAPED_DOUBLE_QUOTE, "You say \\\\\"Yes\\\\\"");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(UNESCAPED_DOUBLE_QUOTE, "I say \"No\"");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(REGULAR_WINDOWS_PATH, "c:\\\\path\\\\in\\\\windows");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(WINDOWS_PATH_WITH_INTERNAL_SPACE, "c:\\\\path in\\\\windows");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(WINDOWS_PATH_WITH_UPPERCASE_VOLUME, "Z:\\\\path\\\\in\\\\windows");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(WINDOWS_PATH_WITH_TRAILING_SLASH, "b:\\\\path\\\\in\\\\windows\\\\");
+        EXPECTED_WINDOWS_PATH_PROPS.setProperty(WINDOWS_PATH_UNESCAPED, "X:\\\\path\\\\in\\\\windows");
+    }
+
+    /**
+     * Verifies that the {@link Utils#processProperties(Properties)} will properly escape Windows paths' double quotes
+     * after such values are loaded from a {@code *.properties} file.
+     *
+     * @throws IOException When the {@code paths.properties} file is not found
+     */
+    @Test
+    public void testProcessProperties() throws IOException {
+        final String propertiesFile = "backslashes.properties";
+        // arrange
+        Properties rawProps = new Properties();
+        try (InputStreamReader inputStreamReader = new InputStreamReader(
+                Thread.currentThread().getContextClassLoader().getResourceAsStream(propertiesFile),
+                StandardCharsets.UTF_8)) {
+            rawProps.load(inputStreamReader);
+        } catch (IOException e) {
+            throw new IOException(
+                    "Failed to load properties from " + propertiesFile + ": " + e.getLocalizedMessage());
+        }
+        // act
+        Properties parsedProps = Utils.processProperties(rawProps);
+        // assert
+        parsedProps.entrySet().stream()
+                .forEach(e -> Assert.assertEquals(e.getValue(), EXPECTED_WINDOWS_PATH_PROPS.get(e.getKey())));
+    }
+}

--- a/plugin/src/test/resources/backslashes.properties
+++ b/plugin/src/test/resources/backslashes.properties
@@ -1,0 +1,8 @@
+escaped.double.quote=You say \\"Yes\\"
+unescaped.double.quote=I say "No"
+
+windows.path.regular=c:\\path\\in\\windows
+windows.path.internal.space=c:\\path in\\windows
+windows.path.uppercase.volume=Z:\\path\\in\\windows
+windows.path.trailing.slash=b:\\path\\in\\windows\\
+windows.path.unescaped=X:\\path\\in\\window\s


### PR DESCRIPTION
In the context of CLI script execution, this is to re-escape backslashes once they have been loaded from the properties file.

The current implementation is a bit wild swince it just handles all the backslash occurrences, since it seems to me the issue is a general one. 
A more specific implementation is could be proposed to handle just values that match the windows path regex.

Feel free to let me know what you think @jfdenise, CC @yersan

Fixes #164 