### PR TITLE
Fix for Issue #309, Add support for WildFly channels

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -489,8 +489,32 @@ In this example, the directory _<project directory>/target/my-maven-repo_ is cre
 The https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/{project-branch}/examples/slim[slim] example shows how to build a slim bootable JAR 
 and generate a local Maven repository used at startup.
 
+[[wildfly_jar_advanced_channels_provisioning]]
+### Provisioning with WildFly Channels
+
+It is possible to configure the plugin to use https://github.com/wildfly-extras/wildfly-channel[WildFly channels]. WildFly Channel yaml files URL and/or Maven Coordinates 
+(version being optional) can be set thanks to the `<channels>` configuration item.
+
+[source,xml]
+----
+<channels>
+    <channel>
+      <url>file://${project.basedir}/my-channel.yaml</url>
+    </channel>
+    <channel>
+      <!-- Use latest channel version -->
+      <groupId>org.foo.bar</groupId>
+      <artifactId>my-channel</artifactId>
+      <!-- Uncomment to use a specific channel version -->
+      <!--<version>2.0.0.Final</version>-->
+    </channel>
+</channels>
+----
+
 [[wildfly_jar_advanced_upgrade]]
 ### Upgrading a bootable JAR
+
+NB: This feature can't be used when WildFly Channels are configured.
 
 The artifacts referenced from JBoss Modules modules and Galleon feature-packs dependencies can be overridden when building a bootable JAR. This mechanism is based on Maven
 dependencies resolution.

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -117,6 +117,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.channel</groupId>
+            <artifactId>channel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.channel</groupId>
+            <artifactId>maven-resolver</artifactId>
+        </dependency>
         <!-- Required by Galleon during provisioning --> 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelMavenArtifactRepositoryManager.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelMavenArtifactRepositoryManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseException;
+import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelMapper;
+import org.wildfly.channel.ChannelSession;
+import org.wildfly.channel.UnresolvedMavenArtifactException;
+import org.wildfly.channel.maven.ChannelCoordinate;
+import org.wildfly.channel.maven.VersionResolverFactory;
+import org.wildfly.channel.spi.ChannelResolvable;
+
+/**
+ * Maven resolver that retrieves versions from configured channels.
+ * This class implements ChannelResolvable to advertise to the galleon plugins that channels
+ * have been enabled.
+ */
+public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, ChannelResolvable {
+    private final ChannelSession channelSession;
+
+    public ChannelMavenArtifactRepositoryManager(List<ChannelCoordinate> channelCoords,
+                                                 RepositorySystem system, RepositorySystemSession contextSession) throws MalformedURLException, UnresolvedMavenArtifactException {
+        this(channelCoords, system, contextSession, null);
+    }
+
+    public ChannelMavenArtifactRepositoryManager(List<ChannelCoordinate> channelCoords,
+                                                 RepositorySystem system,
+                                                 RepositorySystemSession contextSession,
+                                                 List<RemoteRepository> repositories) throws MalformedURLException, UnresolvedMavenArtifactException {
+        DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+        session.setLocalRepositoryManager(contextSession.getLocalRepositoryManager());
+        VersionResolverFactory factory = new VersionResolverFactory(system, session, repositories);
+        List<Channel> channels = factory.resolveChannels(channelCoords);
+        channelSession = new ChannelSession(channels, factory);
+    }
+
+    @Override
+    public void resolve(MavenArtifact artifact) throws MavenUniverseException {
+        try {
+            resolveFromChannels(artifact);
+        } catch (UnresolvedMavenArtifactException ex) {
+            // unable to resolve the artifact through the channel.
+            // if the version is defined, let's resolve it directly
+            if (artifact.getVersion() == null) {
+                throw new MavenUniverseException(ex.getLocalizedMessage(), ex);
+            }
+            try {
+                org.wildfly.channel.MavenArtifact mavenArtifact = channelSession.resolveDirectMavenArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getExtension(), artifact.getClassifier(), artifact.getVersion());
+                artifact.setPath(mavenArtifact.getFile().toPath());
+            } catch (UnresolvedMavenArtifactException e) {
+                throw new MavenUniverseException(ex.getLocalizedMessage(), ex);
+            }
+        }
+    }
+
+    private void resolveFromChannels(MavenArtifact artifact) throws UnresolvedMavenArtifactException {
+        org.wildfly.channel.MavenArtifact result = channelSession.resolveMavenArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getExtension(), artifact.getClassifier());
+        artifact.setVersion(result.getVersion());
+        artifact.setPath(result.getFile().toPath());
+    }
+
+    public void done(Path home) throws MavenUniverseException, IOException {
+        Channel channel = channelSession.getRecordedChannel();
+        Files.write(home.resolve(".channel.yaml"), ChannelMapper.toYaml(channel).getBytes());
+    }
+
+    @Override
+    public void resolveLatestVersion(MavenArtifact artifact) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public boolean isResolved(MavenArtifact artifact) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public boolean isLatestVersionResolved(MavenArtifact artifact, String lowestQualifier) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier, Pattern includeVersion,
+            Pattern excludeVersion) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier, boolean locallyAvailable) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public String getLatestVersion(MavenArtifact artifact) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public String getLatestVersion(MavenArtifact artifact, String lowestQualifier) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public String getLatestVersion(MavenArtifact artifact, String lowestQualifier, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public List<String> getAllVersions(MavenArtifact artifact) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public List<String> getAllVersions(MavenArtifact artifact, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+
+    @Override
+    public void install(MavenArtifact artifact, Path path) throws MavenUniverseException {
+        throw new MavenUniverseException("Channel resolution can't be applied to Galleon universe");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,11 @@
     <version.org.apache.maven.plugin-tools>3.6.4</version.org.apache.maven.plugin-tools>
     <version.org.apache.maven.plugin-plugin>3.6.4</version.org.apache.maven.plugin-plugin>
     <version.org.asciidoctor>2.0.0</version.org.asciidoctor>
-    <version.org.jboss.galleon>5.0.0.Final</version.org.jboss.galleon>
+    <version.org.jboss.galleon>5.0.1.Final</version.org.jboss.galleon>
     <version.org.wildfly.core.wildfly-core>19.0.0.Beta6</version.org.wildfly.core.wildfly-core>
     <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.wildfly.plugins.wildfly-maven-plugin>3.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+    <version.org.wildfly.channel>1.0.0.Alpha13</version.org.wildfly.channel>
     <!-- required by tests -->
     <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
@@ -248,7 +249,19 @@
         <artifactId>wildfly-maven-plugin</artifactId>
         <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
       </dependency>
-      
+
+      <dependency>
+          <groupId>org.wildfly.channel</groupId>
+          <artifactId>channel-core</artifactId>
+          <version>${version.org.wildfly.channel}</version>
+      </dependency>
+
+      <dependency>
+          <groupId>org.wildfly.channel</groupId>
+          <artifactId>maven-resolver</artifactId>
+          <version>${version.org.wildfly.channel}</version>
+      </dependency>
+
     <!-- Needed by tests -->
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>wildfly-jar-cloud-extension</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.channel</groupId>
+            <artifactId>maven-resolver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
         </dependency>

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelsTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelsTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.wildfly.plugins.bootablejar.maven.common.OverriddenArtifact;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.channel.maven.ChannelCoordinate;
+
+/**
+ * @author jdenise
+ */
+public class ChannelsTestCase extends AbstractBootableJarMojoTestCase {
+
+    public ChannelsTestCase() {
+        super("channels", true, null);
+    }
+
+    @Test
+    public void testChannel() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        setupTestChannel(mojo);
+        mojo.execute();
+        final Path dir = getTestDir();
+        Path unzippedJar = checkAndGetWildFlyHome(dir, false, true, null, null, false);
+        try {
+            Path modulesDir = unzippedJar.resolve("modules").resolve("org").resolve("postgresql").resolve("jdbc").resolve("main");
+            Assert.assertTrue(modulesDir.toString(), Files.exists(modulesDir));
+        } finally {
+            BuildBootableJarMojo.deleteDir(unzippedJar);
+        }
+    }
+
+    private void generateChannel(List<MavenArtifact> artifacts, Path file) throws IOException {
+        StringBuilder channel = new StringBuilder();
+        channel.append("name: Test Channel").append(System.lineSeparator());
+        channel.append("description: Test Channel").append(System.lineSeparator());
+        channel.append("streams:").append(System.lineSeparator());
+        for (MavenArtifact artifact : artifacts) {
+            channel.append("  - groupId: ").append(artifact.getGroupId()).append(System.lineSeparator());
+            channel.append("    artifactId: ").append(artifact.getArtifactId()).append(System.lineSeparator());
+            channel.append("    ").append((artifact.hasVersion() ? "version" : "versionPattern" )).append(": ").append((artifact.hasVersion() ? artifact.getVersion() : artifact.getVersionRange())).append(System.lineSeparator());
+        }
+        Files.write(file, channel.toString().getBytes());
+    }
+
+    private void setupTestChannel(BuildBootableJarMojo mojo) throws IOException {
+        List<MavenArtifact> artifacts = new ArrayList<>();
+        MavenArtifact ds = new MavenArtifact();
+        ds.setGroupId("org.wildfly");
+        ds.setArtifactId("wildfly-datasources-galleon-pack");
+        ds.setVersionRange("'2\\.\\d+\\.\\d+\\.Final'");
+        artifacts.add(ds);
+        Path channel = new File(mojo.project.getBasedir().getAbsoluteFile().toPath().toString() + "/my-channel.yaml").toPath();
+        generateChannel(artifacts, channel);
+        ChannelCoordinate coordinate = new ChannelCoordinate();
+        coordinate.setUrl(channel.toUri().toURL());
+        mojo.channels = new ArrayList<>();
+        mojo.channels.add(coordinate);
+    }
+
+    @Test
+    public void testInvalidUpgrade() throws Exception {
+        BuildBootableJarMojo mojo = lookupMojo("package");
+        setupTestChannel(mojo);
+        List<OverriddenArtifact> artifacts = new ArrayList<>();
+        OverriddenArtifact artifact = new OverriddenArtifact();
+        artifact.setGroupId("com.foo");
+        artifact.setArtifactId("bar");
+        artifacts.add(artifact);
+        mojo.overriddenServerArtifacts = artifacts;
+        try {
+            mojo.execute();
+            throw new Exception("Should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX Expected
+            Assert.assertTrue(ex.getLocalizedMessage(), ex.getLocalizedMessage().contains("overridden-server-artifacts can't be configured when channels are configured"));
+        }
+    }
+}

--- a/tests/src/test/resources/projects/channels/pom.xml
+++ b/tests/src/test/resources/projects/channels/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>37</version>
+    </parent>
+    <groupId>org.wildfly.plugins.tests</groupId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <artifactId>test1</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>test</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <version>PLUGIN_VERSION</version>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-galleon-pack:WF_VERSION</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-datasources-galleon-pack</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>jaxrs-server</layer>
+                        <layer>postgresql-driver</layer>
+                    </layers>
+                    <excluded-layers>
+                        <layer>deployment-scanner</layer>
+                    </excluded-layers>
+                    <hollow-jar>true</hollow-jar>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
* Add support for WildFly channels
* Check that artifact upgrade feature can't be enabled with channels
* Deprecate the legacy patching
* Bump Galleon to 5.0.1.Final