### PR TITLE
Adding support for remote dev watch

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -384,6 +384,54 @@ Limitations:
 * No support for resources filtering (include/exclude). The resources directory is watched fully, this means that some re-deploy could be started for resources
 excluded from the project.
 
+### Remote development mode with source watching
+
+Sometimes it might be required to develop the application remotely, for example in a cloud environment. The workflow is the same as the one of link:#wildfly_jar_dev_mode[Development mode with source watching] and it is using the same `dev-watch` goal.
+The only required changes is about configuring how to connect to the remote application using the management API.
+
+So you have to configure your bootable jar to allow remote connection to the management interface.
+For example such a script would create an account *admin/passW0rd!*
+
+[source,bash]
+----
+/subsystem=elytron/security-domain=ManagementDomain:undefine-attribute(name=default-realm)
+/subsystem=elytron/security-domain=ManagementDomain:list-remove(name=realms, index=0)
+/subsystem=elytron/properties-realm=ManagementRealm:remove
+/subsystem=elytron/filesystem-realm=ManagementRealm:add(path=management-realm, relative-to=jboss.server.config.dir)
+reload
+/subsystem=elytron/filesystem-realm=ManagementRealm:add-identity(identity=admin)
+/subsystem=elytron/filesystem-realm=ManagementRealm:add-identity-attribute(identity=admin, name=groups, value=[admin])
+/subsystem=elytron/filesystem-realm=ManagementRealm:set-password(identity=admin, clear={password=passW0rd!})
+/subsystem=elytron/security-domain=ManagementDomain:list-add(name=realms, index=0, value={realm=ManagementRealm})
+/subsystem=elytron/security-domain=ManagementDomain:write-attribute(name=default-realm, value=ManagementRealm
+----
+
+So once you have your application running you can execute the goal locally like this:
+[source,bash]
+----
+mvn  org.wildfly.plugins:wildfly-jar-maven-plugin:dev-watch\
+        -Dwildfly.bootable.remote=true\
+        -Dwildfly.hostname=microprofile-config-bootable-management-ehugonne1-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com\
+        -Dwildfly.port=443\
+        -Dwildfly.bootable.remote.protocol=remote+https\
+        -Dwildfly.bootable.remote.username=admin\
+        -Dwildfly.bootable.remote.password=passW0rd!
+----
+
+Error handling:
+
+The `dev-watch` goal will not exit on error. Errors are advertised in the console.
+
+* Compilation errors are printed in the console. Fix the files, recompilation will occur.
+* Server related errors are printed on the server itself.
+
+Limitations:
+
+* No support for multi modules.
+* No support for resources filtering (include/exclude). The resources directory is watched fully, this means that some re-deploy could be started for resources
+excluded from the project.
+* No support for complete rebuild of the server: you can't expect cli scripts or layer changes to be taken into account. You would need to rebuild the full bootable jar and relaunch it.
+
 ### Development mode with repackaging
 
 In order to speed-up the development of your application, the Maven plugin offers a link:#_dev[dev] goal that builds and starts the bootable JAR only once.
@@ -552,7 +600,7 @@ replace the version referenced in the WildFly Galleon feature-pack used to build
       <overridden-server-artifacts>
         <artifact>
           <groupId>io.undertow</groupId>
-          <artifactId>undertow-core</artifactId>                  
+          <artifactId>undertow-core</artifactId>
         </artifact>
       </overridden-server-artifacts>
     ...

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -106,6 +106,7 @@
         <module>logging-log4j-appender</module>
         <module>mdb-rar</module>
         <module>microprofile-config</module>
+        <module>remote-microprofile-config</module>
         <module>postgresql</module>
         <module>secmanager</module>
         <module>slim</module>

--- a/examples/remote-microprofile-config/README.adoc
+++ b/examples/remote-microprofile-config/README.adoc
@@ -1,0 +1,61 @@
+= Remote MicroProfile Config Example
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+This example shows how to create a MicroProfile Config Web application and how to configure the application to be able to develop remotely on OpenShift.
+
+== Develop the application on OpenShift
+
+=== Build the application locally
+
+* To build: `mvn clean install`
+* Drag and drop the produced `remote-microprofile-config-bootable.jar` on the *Topology* page on OpenShift.
+* Edit the service to add a port for 9990.
+* Add a route to that port: 
+
+[source,bash]
+----
+$ oc create route edge management-remote-microprofile-config-bootable --service=remote-microprofile-config-bootable --port=9990 --insecure-policy='Redirect'
+----
+
+=== Develop the application
+
+* Run the dev watch mode with the *bootable-jar-remote* profile and specify the URL from the route we have created using the *wildfly.hostname* parameter:
+
+[source,bash]
+----
+$ mvn -P bootable-jar-remote -Dwildfly.hostname=$(oc get route management-remote-microprofile-config-bootable --template='{{ .spec.host }}') install
+----
+
+You may also use a command like this one:
+
+[source,bash]
+----
+$ mvn org.wildfly.plugins:wildfly-jar-maven-plugin:dev-watch -Dwildfly.bootable.remote=true -Dwildfly.port=443 -Dwildfly.bootable.remote.protocol=remote+https -Dwildfly.bootable.remote.username=admin -Dwildfly.bootable.remote.password=passW0rd!-Dwildfly.hostname=$(oc get route management-remote-microprofile-config-bootable --template='{{ .spec.host }}')
+----
+
+Check that the application is running properly :
+
+[source,bash]
+----
+$ curl https://$(oc get route remote-microprofile-config-bootable --template='{{ .spec.host }}')
+config1 = Value from Config1 comes from an env var in the DeploymentConfig
+config2 = Value for config2 comes from a properties file inside the application
+config3 = Default value for config3 comes from my code
+----
+
+Once this is done you can edit the code and your changes will be automatically pushed to the OpenShift instance.
+For example:
+ * Change the config2 property value to be "Hello from dev-watch remote" in the file: src/main/resources/META-INF/microprofile-config.properties.
+ * Save your changes
+ * The application is redeployed and the new configuration will be taken into account:
+
+[source,bash]
+----
+$ curl https://$(oc get route remote-microprofile-config-bootable --template='{{ .spec.host }}')
+config1 = Value from Config1 comes from an env var in the DeploymentConfig
+config2 = Hello from dev-watch remote
+config3 = Default value for config3 comes from my code
+----

--- a/examples/remote-microprofile-config/pom.xml
+++ b/examples/remote-microprofile-config/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-examples-parent</artifactId>
+        <version>8.0.0.Final-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>remote-microprofile-config</artifactId>
+    <packaging>war</packaging>
+
+    <name>WildFly Bootable JAR - Remote MicroProfile Config</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>   
+                <configuration>
+                <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                <layers>
+                    <layer>jaxrs-server</layer>
+                    <layer>microprofile-platform</layer>
+                </layers>
+                <plugin-options>
+                    <jboss-fork-embedded>true</jboss-fork-embedded>
+                </plugin-options>
+                <cli-sessions>
+                  <cli-session>
+                      <script-files>
+                          <script>../scripts/management-account.cli</script>
+                      </script-files>
+                  </cli-session>
+              </cli-sessions>
+              <cloud/>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>packaging</id>
+                    <goals>
+                        <goal>package</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+      <profile>
+        <id>bootable-jar-remote</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <inherited>false</inherited>
+                    <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                        <layers>
+                            <layer>jaxrs-server</layer>
+                            <layer>microprofile-platform</layer>
+                        </layers>
+                        <plugin-options>
+                            <jboss-fork-embedded>true</jboss-fork-embedded>
+                        </plugin-options>
+                      <remote>true</remote>
+                      <protocol>remote+https</protocol>
+                      <!--<hostname>management-remote-microprofile-config-bootable-ehugonne1-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com</hostname>-->
+                      <port>443</port>
+                      <username>admin</username>
+                      <password>passW0rd!</password>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>remote-dev</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>dev-watch</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/examples/remote-microprofile-config/src/main/java/org/wildfly/plugins/demo/microprofile/config/MicroProfileConfigEndpoint.java
+++ b/examples/remote-microprofile-config/src/main/java/org/wildfly/plugins/demo/microprofile/config/MicroProfileConfigEndpoint.java
@@ -1,0 +1,45 @@
+package org.wildfly.plugins.demo.microprofile.config;
+
+
+import javax.inject.Inject;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+
+@Path("/")
+public class MicroProfileConfigEndpoint {
+
+
+    @Inject
+    @ConfigProperty(name = "config1", defaultValue = "Default value for config1 comes from my code")
+    String config1;
+
+    @Inject
+    @ConfigProperty(name = "config2", defaultValue = "Default value for config2 comes from my code")
+    String config2;
+
+    @Inject
+    @ConfigProperty(name = "config3", defaultValue = "Default value for config3 comes from my code")
+    String config3;
+
+    @GET
+    @Produces("text/plain")
+    public Response doGet() {
+
+        StringBuilder out = new StringBuilder("config1 = " + config1);
+        out.append("\nconfig2 = " + config2);
+        out.append("\nconfig3 = " + config3);
+
+        return Response.ok(out).build();
+    }
+
+    @ApplicationPath("/")
+    public static class RestApplication extends Application {
+    }
+}

--- a/examples/remote-microprofile-config/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/remote-microprofile-config/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,1 @@
+config2=Value for config2 comes from a properties file inside the application

--- a/examples/remote-microprofile-config/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/remote-microprofile-config/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" bean-discovery-mode="all">
+</beans>

--- a/examples/scripts/management-account.cli
+++ b/examples/scripts/management-account.cli
@@ -1,0 +1,10 @@
+/subsystem=elytron/security-domain=ManagementDomain:undefine-attribute(name=default-realm)
+/subsystem=elytron/security-domain=ManagementDomain:list-remove(name=realms, index=0)
+/subsystem=elytron/properties-realm=ManagementRealm:remove
+/subsystem=elytron/filesystem-realm=ManagementRealm:add(path=management-realm, relative-to=jboss.server.config.dir)
+reload
+/subsystem=elytron/filesystem-realm=ManagementRealm:add-identity(identity=admin)
+/subsystem=elytron/filesystem-realm=ManagementRealm:add-identity-attribute(identity=admin, name=groups, value=[admin])
+/subsystem=elytron/filesystem-realm=ManagementRealm:set-password(identity=admin, clear={password=passW0rd!})
+/subsystem=elytron/security-domain=ManagementDomain:list-add(name=realms, index=0, value={realm=ManagementRealm})
+/subsystem=elytron/security-domain=ManagementDomain:write-attribute(name=default-realm, value=ManagementRealm 

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java
@@ -23,7 +23,13 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+import static org.jboss.as.controller.client.helpers.ClientConstants.ADD_CONTENT;
+import static org.jboss.as.controller.client.helpers.ClientConstants.INPUT_STREAM_INDEX;
+import static org.jboss.as.controller.client.helpers.ClientConstants.TARGET_PATH;
+import static org.jboss.galleon.Constants.CONTENT;
+
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
@@ -63,6 +69,7 @@ import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.util.IoUtils;
 import org.jboss.galleon.util.ZipUtils;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
+
 import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
@@ -71,6 +78,16 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+import org.jboss.as.controller.client.OperationBuilder;
 import org.wildfly.core.launcher.Launcher;
 import org.wildfly.plugins.bootablejar.maven.common.Utils;
 import org.wildfly.plugins.bootablejar.maven.goals.DevWatchContext.BootableAppEventHandler;
@@ -187,9 +204,33 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
     @Parameter(alias= "debug-suspend", defaultValue = "false", property = "wildfly.bootable.debug.suspend")
     private boolean debugSuspend;
 
+    /**
+     * Enable/Disable remote connection.
+     */
+    @Parameter(defaultValue = "false", property = "wildfly.bootable.remote")
+    private boolean remote;
+
+    /**
+     * Remote connection username.
+     */
+    @Parameter(property = "wildfly.bootable.remote.username")
+    private String username;
+
+    /**
+     * Remote connection  password.
+     */
+    @Parameter(property = "wildfly.bootable.remote.password")
+    private String password;
+
+    /**
+     * Remote connection  protocol.
+     */
+    @Parameter(defaultValue = "remote+http", property = "wildfly.bootable.remote.protocol")
+    private String protocol;
+
     private Process process;
     private Path currentServerDir;
-    private final DeploymentController deploymentController = new DeploymentController();
+    private DeploymentController deploymentController;
 
     // Test specific content to have the process to exit on Windows
     static final String TEST_PROPERTY_EXIT = "dev-watch.test.exit.on.file";
@@ -200,9 +241,66 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
         addExtraLayer(MANAGEMENT_LAYER);
     }
 
-    private class DeploymentController {
+    private abstract class DeploymentController {
 
-        void deploy(Path dir) throws Exception {
+        abstract void deploy(Path dir) throws Exception;
+
+        protected void waitRemoved(ModelControllerClient client, String name) throws Exception {
+            ModelNode address = new ModelNode();
+            address.add("deployment", name);
+            waitStatus(client, "failed", Operations.createOperation("read-resource", address));
+            getLog().debug("Deployment " + name + " removed");
+        }
+
+        protected void waitDeploymentUp(ModelControllerClient client, String name) throws Exception {
+            ModelNode address = new ModelNode();
+            address.add("deployment", name);
+            ModelNode op = Operations.createOperation("read-attribute", address);
+            op.get("name").set("status");
+            ModelNode reply = waitStatus(client, "success", op);
+            ModelNode result = reply.get("result");
+            if (result.isDefined()) {
+                String status = result.asString();
+                if ("OK".equals(status)) {
+                    getLog().debug("Deployment " + name + " is up");
+                } else {
+                    getLog().warn("Deployment " + name + " failed, status is " + status);
+                }
+            } else {
+                throw new MojoExecutionException("No status returned for deployment " + name);
+            }
+        }
+
+        protected ModelNode waitStatus(ModelControllerClient client, String status, ModelNode op) throws Exception {
+            int t = timeout * 1000;
+            int waitTime = 100;
+            while (t >= 0) {
+                ModelNode reply = client.execute(op);
+                if (status.equals(reply.get("outcome").asString())) {
+                    return reply;
+                }
+                Thread.sleep(waitTime);
+                t -= waitTime;
+            }
+            throw new MojoExecutionException("Timeout waiting for " + op + " to return " + status + " status");
+        }
+
+        protected void undeploy(ModelControllerClient client, String name) throws Exception {
+            ModelNode composite = Operations.createCompositeOperation();
+            ModelNode steps = composite.get("steps");
+            ModelNode address = new ModelNode();
+            address.add("deployment", name);
+            steps.add(Operations.createOperation("undeploy", address));
+            steps.add(Operations.createOperation("remove", address));
+            getLog().debug("Undeploy " + name);
+            client.execute(composite);
+            getLog().debug("Undeploy " + name + " done");
+        }
+    }
+
+    private class LocalDeploymentController extends DeploymentController {
+        @Override
+        public void deploy(Path dir) throws Exception {
             if (process == null) {
                 return;
             }
@@ -222,45 +320,8 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
             }
         }
 
-        void waitRemoved(ModelControllerClient client, String name) throws Exception {
-            ModelNode address = new ModelNode();
-            address.add("deployment", name);
-            waitStatus(client, "failed", Operations.createOperation("read-resource", address));
-            getLog().debug("Deployment " + name + " removed");
-        }
 
-        void waitDeploymentUp(ModelControllerClient client, String name) throws Exception {
-            ModelNode address = new ModelNode();
-            address.add("deployment", name);
-            ModelNode op = Operations.createOperation("read-attribute", address);
-            op.get("name").set("status");
-            ModelNode reply = waitStatus(client, "success", op);
-            ModelNode result = reply.get("result");
-            if (result.isDefined()) {
-                String status = result.asString();
-                if ("OK".equals(status)) {
-                    getLog().debug("Deployment " + name + " is up");
-                } else {
-                    getLog().warn("Deployment " + name + " failed, status is " + status);
-                }
-            } else {
-                throw new MojoExecutionException("No status returned for deployment " + name);
-            }
-        }
-
-        void undeploy(ModelControllerClient client, String name) throws Exception {
-            ModelNode composite = Operations.createCompositeOperation();
-            ModelNode steps = composite.get("steps");
-            ModelNode address = new ModelNode();
-            address.add("deployment", name);
-            steps.add(Operations.createOperation("undeploy", address));
-            steps.add(Operations.createOperation("remove", address));
-            getLog().debug("Undeploy " + name);
-            client.execute(composite);
-            getLog().debug("Undeploy " + name + " done");
-        }
-
-        boolean deploy(ModelControllerClient client, Path dir) throws Exception {
+        private boolean deploy(ModelControllerClient client, Path dir) throws Exception {
             ModelNode composite = Operations.createCompositeOperation();
             ModelNode steps = composite.get("steps");
             ModelNode address = new ModelNode();
@@ -278,18 +339,81 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
             return "success".equals(reply.get("outcome").asString());
         }
 
-        ModelNode waitStatus(ModelControllerClient client, String status, ModelNode op) throws Exception {
-            int t = timeout * 1000;
-            int waitTime = 100;
-            while (t >= 0) {
-                ModelNode reply = client.execute(op);
-                if (status.equals(reply.get("outcome").asString())) {
-                    return reply;
+    }
+
+    private class RemoteDeploymentController extends DeploymentController {
+        private final String name;
+
+        public RemoteDeploymentController(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void deploy(Path dir) throws Exception {
+            try (ModelControllerClient client = createClient()) {
+                getLog().debug("Trying to connect to the remote management API");
+                ServerHelper.waitForStandalone(client, timeout);
+                getLog().debug("Connection to the remote management API effective");
+                undeploy(client, name);
+                waitRemoved(client, name);
+                boolean success = deploy(client, dir);
+                if (success) {
+                    waitDeploymentUp(client, name);
                 }
-                Thread.sleep(waitTime);
-                t -= waitTime;
+                // We only need this on Windows since it may lock the JAR when the delete process is running
+                if (IS_WINDOWS) {
+                    currentServerDir = getHomeDirectory(client);
+                }
             }
-            throw new MojoExecutionException("Timeout waiting for " + op + " to return " + status + " status");
+        }
+
+        private boolean deploy(ModelControllerClient client, Path deploymentDir) throws Exception {
+            ModelNode composite = Operations.createCompositeOperation();
+            OperationBuilder builder = new OperationBuilder(composite, true);
+            ModelNode steps = composite.get("steps");
+            ModelNode address = new ModelNode();
+            address.add("deployment", name);
+            final ModelNode op = Operations.createOperation("add", address);
+            op.get("runtime-name").set("ROOT.war");
+            ModelNode content = op.get("content").get(0);
+            content.get("empty").set(true);
+            getLog().debug("Deploy " + name);
+            steps.add(op);
+            ModelNode addContentOp = Operations.createOperation(ADD_CONTENT, address);
+            Files.walkFileTree(deploymentDir, new FileVisitor<Path>() {
+                private int index = 0;
+                private int stream = 0;
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    builder.addFileAsAttachment(file);
+                    getLog().debug("Sending file " + file + " to " + deploymentDir.relativize(file).toString() + " with index " + stream);
+                    addContentOp.get(CONTENT).get(index).get(INPUT_STREAM_INDEX).set(stream++);
+                    addContentOp.get(CONTENT).get(index).get(TARGET_PATH).set(deploymentDir.relativize(file).toString());
+                    index++;
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            steps.add(addContentOp);
+            steps.add(Operations.createOperation("deploy", address));
+            ModelNode reply = client.execute(builder.build());
+            getLog().debug("Deploy " + name + " done " + reply.toJSONString(true));
+            return "success".equals(reply.get("outcome").asString());
         }
     }
 
@@ -458,7 +582,22 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
     }
 
     @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (remote) {
+            if (skip) {
+                getLog().debug(String.format("Skipping run of %s:%s", project.getGroupId(), project.getArtifactId()));
+                return;
+            }
+            hollowJar = true;
+            doExecute();
+            return;
+        }
+        super.execute();
+    }
+
+    @Override
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        this.deploymentController = remote ? new RemoteDeploymentController(project.getBuild().getFinalName() + '.' + project.getPackaging()) : new LocalDeploymentController();
         boolean isRebuild = System.getProperty(REBUILD_MARKER) != null;
         if (isRebuild) {
             return;
@@ -482,9 +621,11 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
                     Paths.get(projectBuildDir), sourceDir.toPath(), contextRoot, cliSessions, extraServerContentDirs);
             DevWatchContext ctx = new DevWatchContext(projectContext, watcher);
             ctx.build(true);
-            process = Launcher.of(buildCommandBuilder(false))
-                    .inherit()
-                    .launch();
+            if (!remote) {
+                process = Launcher.of(buildCommandBuilder(false))
+                        .inherit()
+                        .launch();
+            }
             deploymentController.deploy(ctx.getTargetDirectory());
             watch(watcher, ctx);
         } catch (Exception e) {
@@ -543,9 +684,10 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
                 }
 
                 try {
-                    if (handler.rebuildBootableJAR || mustRebuildJar) {
+                    if (!remote && (handler.rebuildBootableJAR || mustRebuildJar)) {
                         // We must first stop the server, on Windows platform
                         // we can't rebuild a Bootable JAR although the server is running.
+                        //If the server is remote, of course rebuilding it doesn't make sense
                         getLog().info("[WATCH] stopping bootable JAR");
                         shutdownContainer();
                         getLog().info("[WATCH] server stopped");
@@ -1012,6 +1154,30 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
     }
 
     private ModelControllerClient createClient() throws UnknownHostException {
+        if (remote && username != null && password != null) {
+            return ModelControllerClient.Factory.create(protocol, hostname, port, (Callback[] callbacks) -> {
+                for (Callback current : callbacks) {
+                    if (current instanceof NameCallback) {
+                        NameCallback ncb = (NameCallback) current;
+                        ncb.setName(username);
+                        getLog().debug("set user " + username);
+                    } else if (current instanceof PasswordCallback) {
+                        PasswordCallback pcb = (PasswordCallback) current;
+                        pcb.setPassword(password.toCharArray());
+                        StringBuilder builder = new StringBuilder("set password ");
+                        for(int i = 0; i < password.length(); i++) {
+                            builder.append('*');
+                        }
+                        getLog().debug(builder.toString());
+                    } else if (current instanceof RealmCallback) {
+                        RealmCallback rcb = (RealmCallback) current;
+                        rcb.setText(rcb.getDefaultText());
+                    } else {
+                        throw new UnsupportedCallbackException(current);
+                    }
+                }
+            });
+        }
         return ModelControllerClient.Factory.create(hostname, port);
     }
 


### PR DESCRIPTION
Issue #321  dev-watch can now be used with a remote instance provided that the management API is accessible.

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>