### PR TITLE
Fix docs on remote development mode

### DIFF
--- a/docs/guide/intro/index.adoc
+++ b/docs/guide/intro/index.adoc
@@ -397,7 +397,7 @@ For example such a script would create an account *admin/passW0rd!*
 /subsystem=elytron/security-domain=ManagementDomain:list-remove(name=realms, index=0)
 /subsystem=elytron/properties-realm=ManagementRealm:remove
 /subsystem=elytron/filesystem-realm=ManagementRealm:add(path=management-realm, relative-to=jboss.server.config.dir)
-reload
+reload --start-mode=admin-only
 /subsystem=elytron/filesystem-realm=ManagementRealm:add-identity(identity=admin)
 /subsystem=elytron/filesystem-realm=ManagementRealm:add-identity-attribute(identity=admin, name=groups, value=[admin])
 /subsystem=elytron/filesystem-realm=ManagementRealm:set-password(identity=admin, clear={password=passW0rd!})


### PR DESCRIPTION
The cli-script example showing how to create an admin account contains a reload command. Without any parameters this reloads the server in normal mode. If this script is executed during configuration of the bootable jar, this causes unexpected side effects as the server was originally started in embedded mode (which implies admin-mode) and switches to normal mode after reloading. This, for instance, results in the application artifact being deployed and started during server configuration which is likely to cause errors as configuration is not completed yet.