### PR TITLE
Preconfigure Extension

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -41,5 +41,6 @@
 
   <modules>
     <module>cloud</module>
+      <module>preconfigure</module>
   </modules>
 </project>

--- a/extensions/preconfigure/pom.xml
+++ b/extensions/preconfigure/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-jar-extensions-parent</artifactId>
+        <version>8.1.1.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-jar-preconfigure-extension</artifactId>
+
+    <name>WildFly Bootable JAR preconfigure extensions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-jar-boot</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/preconfigure/src/main/java/org/wildfly/plugins/bootablejar/extensions/preconfigure/PreconfigureExtension.java
+++ b/extensions/preconfigure/src/main/java/org/wildfly/plugins/bootablejar/extensions/preconfigure/PreconfigureExtension.java
@@ -1,0 +1,114 @@
+package org.wildfly.plugins.bootablejar.extensions.preconfigure;
+
+import org.wildfly.core.jar.boot.RuntimeExtension;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Allows a bootable jar to access and run the extension/preconfigure script inside the
+ * wildfly distribution.
+ *
+ * @author chrisruffalo
+ */
+public class PreconfigureExtension implements RuntimeExtension {
+
+    /**
+     * The name of the OS so that we can determine what type of script to look for/run.
+     * This probably doesn't matter because the vast majority of use-cases will be
+     * for linux or something that can interpret a shell script without prompting.
+     */
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+
+    /**
+     * Simple method to determine if the bootable jar is running on windows
+     *
+     * @return true when running on windows, false otherwise
+     */
+    private boolean isWindows() {
+        return OS.startsWith("windows");
+    }
+
+    @Override
+    public void boot(List<String> list, Path path) throws Exception {
+        // check extension directory exists
+        final Path extensions = path.resolve("extensions");
+        if (!Files.exists(extensions)) {
+            System.err.println("no extension directory found in jboss home");
+            return;
+        }
+        // check that the path to the actual script exists
+        final Path preconfigure = extensions.resolve("preconfigure." + (isWindows() ? "bat" : "sh"));
+        if (!Files.exists(preconfigure)) {
+            System.err.printf("no preconfigure script (%s) found in preconfigure path%n", preconfigure.getFileName());
+            return;
+        }
+        // before trying to execute the script, ensure that it is executable
+        if (!Files.isExecutable(preconfigure)) {
+            System.err.printf("the preconfiguration script (%s) is not executable", preconfigure);
+            return;
+        }
+
+        // show what we are about to execute
+        System.out.println("executing preconfigure: " + preconfigure.toString());
+
+        // build a process
+        final ProcessBuilder builder = new ProcessBuilder();
+        builder.command(preconfigure.toString());
+        // re-use environment and ensure jboss path matches the location of the script
+        builder.environment().putAll(System.getenv());
+        builder.environment().put("JBOSS_HOME", path.toString());
+
+        // start the process and open the input/error streams so that the exact script can be relayed back
+        // to the console/user/output
+        final Process process = builder.start();
+        try (
+            final BufferedReader stdReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            final BufferedReader errReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+        ) {
+            // create threads that can independently read from each reader when ready
+            final Thread std = reader(stdReader, System.out);
+            final Thread err = reader(errReader, System.err);
+
+            // start the reading threads so they will begin consuming and printing
+            std.start();
+            err.start();
+
+            // wait for the process to end and collect the exit code, also wait
+            // for the reader threads to end which will ensure that all the data
+            // is read from the streams. (missing lines could cause confusion
+            // for users if they do not get the full status/error)
+            int exitVal = process.waitFor();
+            std.join();
+            err.join();
+            System.out.println("finished with exit code: " + exitVal);
+        }
+    }
+
+    /**
+     * Create a threaded reader to read input from the reader so that the output from the process
+     * shows up in the console int the correct order
+     *
+     * @param reader that serves as the source of the lines
+     * @param outputStream to route the output to
+     * @return a thread ready to be started
+     */
+    private Thread reader(final BufferedReader reader, final PrintStream outputStream) {
+        return  new Thread(() -> {
+            String line;
+            while (true) {
+                try {
+                    if ((line = reader.readLine()) == null) break;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                outputStream.println(line);
+            }
+        });
+    }
+}

--- a/extensions/preconfigure/src/main/resources/META-INF/services/org.wildfly.core.jar.boot.RuntimeExtension
+++ b/extensions/preconfigure/src/main/resources/META-INF/services/org.wildfly.core.jar.boot.RuntimeExtension
@@ -1,0 +1,1 @@
+org.wildfly.plugins.bootablejar.extensions.preconfigure.PreconfigureExtension

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.jboss.galleon.config.ConfigId;
 import org.wildfly.plugins.bootablejar.maven.common.Utils.ProvisioningSpecifics;
+import org.wildfly.plugins.bootablejar.maven.preconfigure.PreconfigureConfig;
 
 /**
  * Build a bootable JAR containing application and provisioned server
@@ -46,6 +47,9 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
      */
     @Parameter(alias = "cloud")
     CloudConfig cloud;
+
+    @Parameter(alias = "preconfigure")
+    PreconfigureConfig preconfigure;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -102,6 +106,9 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
     protected void copyExtraContentInternal(Path wildflyDir, Path contentDir) throws Exception {
         if (cloud != null) {
            cloud.copyExtraContent(this, wildflyDir, contentDir);
+        }
+        if (preconfigure != null && preconfigure.isEnabled()) {
+            preconfigure.copyExtraContent(this, wildflyDir, contentDir);
         }
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/preconfigure/PreconfigureConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/preconfigure/PreconfigureConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugins.bootablejar.maven.preconfigure;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
+import org.jboss.galleon.util.ZipUtils;
+import org.wildfly.plugins.bootablejar.maven.goals.BuildBootableJarMojo;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Add a configuration capability for enabling/disabling the preconfigure extension scripts
+ * in a bootable jar deployment.
+ *
+ * @author chrisruffalo
+ */
+public class PreconfigureConfig {
+
+    boolean enabled = false;
+
+    public void copyExtraContent(BuildBootableJarMojo mojo, Path wildflyDir, Path contentDir) throws IOException, PlexusConfigurationException, MojoExecutionException {
+        Path extensionJar = mojo.resolveArtifact("org.wildfly.plugins", "wildfly-jar-preconfigure-extension", null, mojo.retrievePluginVersion());
+        ZipUtils.unzip(extensionJar, contentDir); // todo: the service file needs to be concatenated
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}


### PR DESCRIPTION
What this does:
- Adds a new configuration item that allows inclusion of the preconfigure extension
- Preconfigure extension is a RuntimeExtension that will run the ${JBOSS_HOME}/extension/preconfigure.sh script after installing the wildfly distribution but before launching the server

What needs to be done:
- What to even test here (if anything)
- When adding both the cloud extension and the preconfigure extension the service file needs to have both classes, not just one

Why this is useful:
In some situations a bootable jar still needs to execute shell commands to finish configuration before the container can run _but after_ the wildfly container is started.

Some examples:
- adding application users at runtime from secrets (not having a preconfigured/build-time application-users.properties)
- augmenting truststore at runtime with k8s/openshift service signing secrets or certificates that are not available at build time