### PR TITLE
Fix for Issue #325, [WF28] Support for wildfly-ee-galleon-pack

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/BuildBootableJarMojo.java
@@ -64,8 +64,7 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
         return false;
     }
 
-    @Override
-    protected void willProvision(ProvisioningSpecifics specifics) throws
+    protected ConfigId willProvision(ProvisioningSpecifics specifics) throws
             MojoExecutionException {
         if (!isPackageDev()) {
             if (cloud != null) {
@@ -76,6 +75,7 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
                 }
             }
         }
+        return specifics.getDefaultConfig(cloud != null);
     }
 
     @Override
@@ -86,15 +86,6 @@ public class BuildBootableJarMojo extends AbstractBuildBootableJarMojo {
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
-        }
-    }
-
-    @Override
-    protected ConfigId getDefaultConfig() {
-        if(cloud == null) {
-            return super.getDefaultConfig();
-        } else {
-            return new ConfigId("standalone", "standalone-microprofile-ha.xml");
         }
     }
 

--- a/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-interfaces-script.cli
+++ b/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-interfaces-script.cli
@@ -27,7 +27,14 @@ if (outcome == success) of /socket-binding-group=standard-sockets/socket-binding
   /socket-binding-group=standard-sockets/socket-binding=https:write-attribute(name=interface,value=bindall)
 end-if
 
-#remove ajp
+#remove ajp and modcluster
+if (outcome == success) of /subsystem=modcluster:read-resource
+  /subsystem=modcluster:remove
+end-if
+if (outcome == success) of /subsystem=undertow/server=default-server/ajp-listener=ajp:read-resource
+  /subsystem=undertow/server=default-server/ajp-listener=ajp:remove
+end-if
+
 if (outcome == success) of /socket-binding-group=standard-sockets/socket-binding=ajp:read-resource
   /socket-binding-group=standard-sockets/socket-binding=ajp:remove
 end-if

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Require Java 11 -->
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
-    <version.wildfly>27.0.0.Final</version.wildfly>
+    <version.wildfly>28.0.0.Beta1</version.wildfly>
     <!-- docs properties -->
     <docs.project.branch>main</docs.project.branch>
     <docs.wildfly.major>27.0</docs.wildfly.major>
@@ -64,7 +64,7 @@
     <version.org.apache.maven.plugin-tools>3.6.4</version.org.apache.maven.plugin-tools>
     <version.org.apache.maven.plugin-plugin>3.6.4</version.org.apache.maven.plugin-plugin>
     <version.org.asciidoctor>2.0.0</version.org.asciidoctor>
-    <version.org.jboss.galleon>5.0.8.Final</version.org.jboss.galleon>
+    <version.org.jboss.galleon>5.0.9.Final</version.org.jboss.galleon>
     <version.org.wildfly.core.wildfly-core>20.0.0.Beta8</version.org.wildfly.core.wildfly-core>
     <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.wildfly.plugins.wildfly-maven-plugin>4.1.0.Beta4</version.org.wildfly.plugins.wildfly-maven-plugin>
@@ -87,11 +87,15 @@
 
     <maven.test.skip>false</maven.test.skip>
     <skipTests>${maven.test.skip}</skipTests>
-
-    <test.ee.fpl>wildfly-ee@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.ee.fpl>
+    
+    <test.default.ee.config>standalone.xml</test.default.ee.config>
+    <test.default.ee.cloud.config>standalone-ha.xml</test.default.ee.cloud.config>
+    <test.default.config>standalone-microprofile.xml</test.default.config>
+    <test.default.cloud.config>standalone-microprofile-ha.xml</test.default.cloud.config>
     <test.fpl>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.fpl>
+    <test.ee.fpl>wildfly-ee@maven(org.jboss.universe:community-universe)#${version.wildfly}</test.ee.fpl>
     <test.version.wildfly>${version.wildfly}</test.version.wildfly>
-    <test.version.wildfly-ee.upgrade>27.0.0.Beta1</test.version.wildfly-ee.upgrade>
+    <test.version.wildfly-ee.upgrade>27.0.1.Final</test.version.wildfly-ee.upgrade>
     <test.patch.ee.product>WildFly EE</test.patch.ee.product>
     <test.patch.product>WildFly Full</test.patch.product>
     <test.patch.version>${version.wildfly}</test.patch.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -182,7 +182,6 @@
                         </goals>
                         <phase>none</phase>
                     </execution>
-                    <!-- run subset of tests with wildfly-ee -->
                     <execution>
                         <id>default-test-wildfly-ee</id>
                         <goals>
@@ -193,9 +192,27 @@
                             <systemPropertyVariables>
                                 <test.fpl>${test.ee.fpl}</test.fpl>
                                 <test.health>health</test.health>
+                                <test.default.config>${test.default.ee.config}</test.default.config>
+                                <test.default.cloud.config>${test.default.ee.cloud.config}</test.default.cloud.config>
+                                <test.patch.product>${test.patch.ee.product}</test.patch.product>
                             </systemPropertyVariables>
+                            <excludes>
+                                <!-- This test upgrades the wildfly-ee dependency that is not a dependency when provisioning wildfly-ee -->
+                                <exclude>org.wildfly.plugins.bootablejar.maven.goals.UpgradeArtifactFPLTestCase.java</exclude>
+                                <!-- We can't mix an FP dep that packages configgen in the FP zip. It is not compatible -->
+                                <exclude>org.wildfly.plugins.bootablejar.maven.goals.UpgradeArtifactTestCase.java</exclude>
+                            </excludes>
                             <includes>
-                                <include>org/wildfly/plugins/bootablejar/maven/goals/OpenShiftConfigurationTestCase.java</include>
+                                <!-- Other tests would be redundant with wildfly-ee-galleon-pack -->
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultCloudConfigurationExcludeLayerTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultCloudConfigurationTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultCloudConfigurationWithFPTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultConfigurationSecurityManagerTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultConfigurationTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.DefaultConfigurationWithFPTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.IncludedDefaultConfigurationCloudTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.IncludedDefaultConfigurationNoLayersTestCase</include>
+                                <include>org.wildfly.plugins.bootablejar.maven.goals.IncludedDefaultConfigurationTestCase</include>
                             </includes>
                         </configuration>
                     </execution>
@@ -210,7 +227,15 @@
                                 <test.fpl>${test.fpl}</test.fpl>
                                 <test.patch.product>${test.patch.product}</test.patch.product>
                                 <test.health>microprofile-health</test.health>
+                                <test.default.config>${test.default.config}</test.default.config>
+                                <test.default.cloud.config>${test.default.cloud.config}</test.default.cloud.config>
+                                <test.patch.product>${test.patch.product}</test.patch.product>
                             </systemPropertyVariables>
+                            <excludes>
+                                <!-- We can't mix an FP dep that packages config-gen in the FP zip. It is not compatible -->
+                                <exclude>org.wildfly.plugins.bootablejar.maven.goals.UpgradeArtifactTestCase.java</exclude>
+                                <exclude>org.wildfly.plugins.bootablejar.maven.goals.UpgradeArtifactFPLTestCase.java</exclude>
+                            </excludes>
                         </configuration>
                     </execution>
                 </executions>
@@ -224,75 +249,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <!-- Run all tests with wildfly-ee galleon feature-pack -->
-            <id>wildfly-ee</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>${client.jvm.jpms.args}</argLine>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>default-test-wildfly-ee</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>default-test-wildfly-full</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>all-test-wildfly-ee</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <test.fpl>${test.ee.fpl}</test.fpl>
-                                        <test.health>health</test.health>
-                                        <test.patch.product>${test.patch.ee.product}</test.patch.product>
-                                    </systemPropertyVariables>
-                                    <excludes>
-                                        <!-- Excluded due to no support for default configuration when provisioning wildfly-ee galleon feature-pack. -->
-                                        <!-- Exclusion will be removed when standalone.xml and standalone-ha.xml are expressed with Galleon layers 
-                                        and the plugin discovers default configurations. -->
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/UpgradeArtifactFPLTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/PatchExistingMiscTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationSecurityManagerTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationWithFPTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationCloudTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationNoLayersTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/IncludedDefaultConfigurationTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultConfigurationWithFPTestCase.java</exclude>
-                                        <exclude>org/wildfly/plugins/bootablejar/maven/goals/DefaultCloudConfigurationExcludeLayerTestCase.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBootableJarMojoTestCase.java
@@ -70,12 +70,16 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
     static final String WILDFLY_GROUP_ID = "test.groupid.wildfly";
     static final String PLUGIN_VERSION = "test.plugin.version";
     private static final String TEST_REPLACE = "TEST_REPLACE";
+    private static final String TEST_DEFAULT_CONFIG_REPLACE = "TEST_DEFAULT_CONFIG_REPLACE";
+    private static final String TEST_DEFAULT_CLOUD_CONFIG_REPLACE = "TEST_DEFAULT_CLOUD_CONFIG_REPLACE";
     private static final String TEST_REPLACE_WF_EE_VERSION = "WF_EE_VERSION";
     private static final String TEST_REPLACE_WF_GROUPID = "WF_GROUPID";
     private static final String TEST_REPLACE_WF_VERSION = "WF_VERSION";
     static final String PLUGIN_VERSION_TEST_REPLACE = "PLUGIN_VERSION";
     static final String TEST_FILE = "test-" + AbstractBuildBootableJarMojo.BOOTABLE_SUFFIX + ".jar";
     static final String HEALTH = System.getProperty("test.health");
+    static final String DEFAULT_CONFIG = "test.default.config";
+    static final String DEFAULT_CLOUD_CONFIG = "test.default.cloud.config";
     private final String projectFile;
     private final boolean copyWar;
     private final String provisioning;
@@ -165,6 +169,12 @@ public abstract class AbstractBootableJarMojoTestCase extends AbstractConfigured
             }
             if (s.contains(TEST_REPLACE_WF_GROUPID)) {
                 s = s.replace(TEST_REPLACE_WF_GROUPID, System.getProperty(WILDFLY_GROUP_ID));
+            }
+            if (s.contains(TEST_DEFAULT_CONFIG_REPLACE)) {
+                s = s.replace(TEST_DEFAULT_CONFIG_REPLACE, System.getProperty(DEFAULT_CONFIG));
+            }
+            if (s.contains(TEST_DEFAULT_CLOUD_CONFIG_REPLACE)) {
+                s = s.replace(TEST_DEFAULT_CLOUD_CONFIG_REPLACE, System.getProperty(DEFAULT_CLOUD_CONFIG));
             }
             content.append(s).append(System.lineSeparator());
         }

--- a/tests/src/test/resources/poms/test12-pom.xml
+++ b/tests/src/test/resources/poms/test12-pom.xml
@@ -19,7 +19,7 @@
                     <feature-packs>
                         <feature-pack>
                             <location>TEST_REPLACE</location>
-                            <included-default-config>standalone-microprofile.xml</included-default-config>
+                            <included-default-config>TEST_DEFAULT_CONFIG_REPLACE</included-default-config>
                         </feature-pack>
                     </feature-packs>
                     <excluded-layers>

--- a/tests/src/test/resources/poms/test17-pom.xml
+++ b/tests/src/test/resources/poms/test17-pom.xml
@@ -19,7 +19,7 @@
                     <feature-packs>
                         <feature-pack>
                             <location>TEST_REPLACE</location>
-                            <included-default-config>standalone-microprofile.xml</included-default-config>
+                            <included-default-config>TEST_DEFAULT_CONFIG_REPLACE</included-default-config>
                         </feature-pack>
                     </feature-packs>
                 </configuration>

--- a/tests/src/test/resources/poms/test20-pom.xml
+++ b/tests/src/test/resources/poms/test20-pom.xml
@@ -19,7 +19,7 @@
                     <feature-packs>
                         <feature-pack>
                             <location>TEST_REPLACE</location>
-                            <included-default-config>standalone-microprofile.xml</included-default-config>
+                            <included-default-config>TEST_DEFAULT_CONFIG_REPLACE</included-default-config>
                         </feature-pack>
                     </feature-packs>
                     <cloud/>


### PR DESCRIPTION
* Bump dependency to WF28, wildfly-maven-plugin 4.1.0.Beta3, galleon 5.0.9.Final.
* Support non microprofile default configs and non microprofile health.
* Run tests with wildfly-ee-galleon-pack and wildfly-galleon-pack.