### PR TITLE
Allow setting manifest coordinates via system property

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractBuildBootableJarMojo.java
@@ -82,6 +82,7 @@ import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
 import org.jboss.galleon.util.IoUtils;
 import org.jboss.galleon.util.ZipUtils;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
+import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.core.MavenJBossLogger;
 import org.wildfly.plugin.tools.PluginProgressTracker;
 
@@ -352,9 +353,40 @@ public abstract class AbstractBuildBootableJarMojo extends AbstractMojo {
     String installArtifactClassifier;
 
     /**
-     * List of channel URL and/or Maven coordinates (version being optional).
+     * A list of channels used for resolving artifacts while provisioning.
+     * <p>
+     * Defining a channel:
+     *
+     * <pre>
+     * <channels>
+     *     <channel>
+     *         <manifest>
+     *             <groupId>org.wildfly.channels</groupId>
+     *             <artifactId>wildfly-30.0</artifactId>
+     *         </manifest>
+     *     </channel>
+     *     <channel>
+     *         <manifest>
+     *             <url>https://example.example.org/channel/30</url>
+     *         </manifest>
+     *     </channel>
+     * </channels>
+     * </pre>
+     * </p>
+     * <p>
+     * The {@code wildfly.channels} property can be used pass a comma delimited string for the channels. The channel
+     * can be a URL or a Maven GAV. If a Maven GAV is used, the groupId and artifactId are required.
+     * <br>
+     * Examples:
+     *
+     * <pre>
+     *     -Dwildfly.channels=&quot;https://channels.example.org/30&quot;
+     *     -Dwildfly.channels=&quot;https://channels.example.org/30,org.example.channel:updates-30&quot;
+     *     -Dwildfly.channels=&quot;https://channels.example.org/30,org.example.channel:updates-30:1.0.2&quot;
+     * </pre>
+     * </p>
      */
-    @Parameter(alias = "channels", required = false)
+    @Parameter(alias = "channels", property = PropertyNames.CHANNELS)
     List<ChannelConfiguration> channels;
 
     MavenProjectArtifactVersions artifactVersions;
@@ -496,7 +528,7 @@ public abstract class AbstractBuildBootableJarMojo extends AbstractMojo {
     }
 
     private boolean isChannelsProvisioning() {
-        return channels != null;
+        return channels != null && !channels.isEmpty();
     }
 
     protected boolean isPackageDev() {

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelConfiguration.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelConfiguration.java
@@ -16,8 +16,12 @@
  */
 package org.wildfly.plugins.bootablejar.maven.goals;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.wildfly.channel.Channel;
@@ -31,6 +35,7 @@ import org.wildfly.channel.Repository;
  * @author jdenise
  */
 public class ChannelConfiguration {
+    private static final Pattern FILE_MATCHER = Pattern.compile("^(file:|http://|https://).*");
 
     private ChannelManifestCoordinate manifest;
 
@@ -43,6 +48,28 @@ public class ChannelConfiguration {
 
     void setManifest(ChannelManifestCoordinate manifest) {
         this.manifest = manifest;
+    }
+
+    public void set(final String channel) {
+        // Is this a URL?
+        if (FILE_MATCHER.matcher(channel).matches()) {
+            try {
+                this.manifest = new ChannelManifestCoordinate(new URL(channel));
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Failed to parse URL for " + channel, e);
+            }
+        } else {
+            // Treat as a Maven GAV
+            final String[] coords = channel.split(":");
+            if (coords.length > 2) {
+                this.manifest = new ChannelManifestCoordinate(coords[0], coords[1], coords[2]);
+            } else if (coords.length == 2) {
+                this.manifest = new ChannelManifestCoordinate(coords[0], coords[1]);
+            } else {
+                throw new IllegalArgumentException(
+                        "A channel must be a Maven GAV in the format groupId:artifactId:version. The groupId and artifactId are both required.");
+            }
+        }
     }
 
     private void validate() throws MojoExecutionException {

--- a/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelConfigurationTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/ChannelConfigurationTestCase.java
@@ -1,0 +1,75 @@
+package org.wildfly.plugins.bootablejar.maven.goals;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.channel.Channel;
+
+import java.util.Collections;
+
+public class ChannelConfigurationTestCase {
+
+    @Test
+    public void testFileUrlFromString() throws Exception {
+        {
+            // Make sure that the notation "file:relative/path" is handled like a file URL, rather than a Maven G:A.
+
+            String url = "file:path/to/manifest.yaml";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(url);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getUrl());
+            Assert.assertEquals(url, channel.getManifestCoordinate().getUrl().toExternalForm());
+        }
+
+        {
+            // The notation "file://relative/path" should still be handled like a file URL too.
+
+            String url = "file://path/to/manifest.yaml";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(url);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getUrl());
+            Assert.assertEquals(url, channel.getManifestCoordinate().getUrl().toExternalForm());
+        }
+    }
+
+    @Test
+    public void testHttpUrlFromString() throws Exception {
+        String url = "http://wildfly.org/path/to/manifest";
+        ChannelConfiguration configuration = new ChannelConfiguration();
+        configuration.set(url);
+        Channel channel = configuration.toChannel(Collections.emptyList());
+
+        Assert.assertNotNull(channel.getManifestCoordinate().getUrl());
+        Assert.assertEquals(url, channel.getManifestCoordinate().getUrl().toExternalForm());
+    }
+
+    @Test
+    public void testMavenGavFromString() throws Exception {
+        {
+            String gav = "g:a:v";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(gav);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getMaven());
+            Assert.assertEquals("g", channel.getManifestCoordinate().getMaven().getGroupId());
+            Assert.assertEquals("a", channel.getManifestCoordinate().getMaven().getArtifactId());
+            Assert.assertEquals("v", channel.getManifestCoordinate().getMaven().getVersion());
+        }
+
+        {
+            String gav = "g:a";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(gav);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getMaven());
+            Assert.assertEquals("g", channel.getManifestCoordinate().getMaven().getGroupId());
+            Assert.assertEquals("a", channel.getManifestCoordinate().getMaven().getArtifactId());
+            Assert.assertNull(channel.getManifestCoordinate().getMaven().getVersion());
+        }
+    }
+}


### PR DESCRIPTION
This ports the ability to configure manifest locations via the `wildfly.channels` system property from the wildfly-maven-plugin (https://github.com/wildfly/wildfly-maven-plugin/pull/417).

It was requested to have this in the jar plugin as well (Cc @mnovak1).