### PR TITLE
CLOUD-4211 Cloud clustering profiles should configure a distributed caches instead of a replicated ones

### DIFF
--- a/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-infinispan-script.cli
+++ b/plugin/src/main/resources/org/wildfly/plugins/bootablejar/maven/cloud/openshift-infinispan-script.cli
@@ -1,8 +1,7 @@
-# Infinispan, add a more efficient cache if we already have the dist distributed cache.
+# Infinispan
+# Add a distributed cache optimized for the cloud called 'sessions' if we already have the dist distributed cache.
 if (outcome == success) of /subsystem=infinispan/cache-container=web/distributed-cache=dist:read-resource
-  /subsystem=infinispan/cache-container=web/replicated-cache=repl:add
-  /subsystem=infinispan/cache-container=web:write-attribute(name=default-cache,value=repl)
-  /subsystem=infinispan/cache-container=web/replicated-cache=repl/component=locking:add(isolation=REPEATABLE_READ
-  /subsystem=infinispan/cache-container=web/replicated-cache=repl/component=transaction:add(mode=BATCH
-  /subsystem=infinispan/cache-container=web/replicated-cache=repl/store=file:add  
+  /subsystem=infinispan/cache-container=web/distributed-cache=sessions:add
+  /subsystem=infinispan/cache-container=web/distributed-cache=sessions/component=expiration:add(interval=0)
+  /subsystem=infinispan/cache-container=web:write-attribute(name=default-cache,value=sessions)
 end-if


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/CLOUD-4211