### PR TITLE
[9.x] Fix dev-watch tests server shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
+          name: project-src-${{ matrix.os }}-${{ matrix.java }}
+          path: |
+           !**/bootable-jar-build-artifacts/**
+           **/tests/target/devwatch*/src/**
+           **/tests/target/devwatch*/target/deployments/**
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
           name: logs-${{ matrix.os }}-${{ matrix.java }}
           path: | 
            !**/bootable-jar-build-artifacts/**

--- a/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java
@@ -1299,6 +1299,7 @@ public final class DevWatchBootableJarMojo extends AbstractDevBootableJarMojo {
                     ServerHelper.shutdownStandalone(client, timeout);
                 } catch (Throwable ignore) {
                     process.destroy();
+                    getLog().warn("Server process has been destroyed due to raised exception when shutting down the server. Exception: " + ignore);
                 }
                 try {
                     if (!process.waitFor(timeout, TimeUnit.SECONDS)) {

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractDevWatchTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/AbstractDevWatchTestCase.java
@@ -154,7 +154,8 @@ public abstract class AbstractDevWatchTestCase extends AbstractBootableJarMojoTe
 
     @Override
     public void shutdownServer() throws Exception {
-        super.shutdownServerAsync();
+        // Do not initiate shutdown, when the mvn process will exit, shutdown hook will shutdown any running server
+        //super.shutdownServerAsync();
 
         if (process != null) {
             if (retCode != null) {

--- a/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchTestCase.java
+++ b/tests/src/test/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchTestCase.java
@@ -92,14 +92,24 @@ public class DevWatchTestCase extends AbstractDevWatchTestCase {
         assertTrue(pollBodyContent(url, expectedNewContent));
 
         Thread.sleep(3000);
-        // Update Java file and check that previous resources update is reflected
+        // In some very rare cases we got an empty resource file in the expoded deployment.
+        // Allthough in the previous check the resource file has been tested to be updated.
+        // This is a cause of test instability that we are removing with a simpler use-case, make a change to the resource file
+        // to force again having it updated.
+        // Update Java file and check that resources update is reflected
+        String testMsg2 = " The test2!";
+        props.setProperty("msg", testMsg2);
+        try (FileOutputStream output = new FileOutputStream(resourcesFile.toFile())) {
+            props.store(output, null);
+        }
+        Thread.sleep(3000);
         javaFile = getTestDir().resolve("src").resolve("main").resolve("java").
                 resolve("org").resolve("wildfly").resolve("plugins").resolve("demo").resolve("jaxrs").resolve("HelloWorldEndpoint.java");
         str = new String(Files.readAllBytes(javaFile), "UTF-8");
         radical = "Hi guys ";
         patchedRadical = "FOOFOO ";
         str = str.replace(radical, patchedRadical);
-        expectedNewContent = patchedRadical + testMsg;
+        expectedNewContent = patchedRadical + testMsg2;
         Files.write(javaFile, str.getBytes());
 
         assertTrue(pollBodyContent(url, expectedNewContent));

--- a/tests/src/test/resources/projects/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/HelloWorldEndpoint.java
+++ b/tests/src/test/resources/projects/jaxrs/src/main/java/org/wildfly/plugins/demo/jaxrs/HelloWorldEndpoint.java
@@ -20,6 +20,7 @@ public class HelloWorldEndpoint {
             props = new Properties();
             props.load(inputStream);
         }
+        System.out.println("CLASSLOADER " + HelloWorldEndpoint.class.getClassLoader());
         InputStream inputStream2 = HelloWorldEndpoint.class.getResourceAsStream("/myresources2.properties");
         Properties props2 = null;
         if (inputStream2 != null) {
@@ -30,7 +31,9 @@ public class HelloWorldEndpoint {
                 inputStream2.close();
             }
         }
-
+        for(String k : props.stringPropertyNames()) {
+            System.out.println("KEY " + k + "=" + props.getProperty(k));
+        }
         //return Response.ok("Hello from " + "XXXWildFly bootable jar!").build();
         return Response.ok("Hello from " + props.getProperty("msg") + (props2 == null ? "" : " " + props2.getProperty("msg"))).build();
     }


### PR DESCRIPTION
It has been reported failing test execution on Windows of some DevWatch test. Although the test is passing, the test fails when shutting down the server.

I also updated the DevWatchTestCase to remove another instability.

I suspect the server process shutdown hook to not be run on Windows. We  have 2 shutdown in //, with one of the two receiving an exception when sending :shutdown , this exception causes abrupt termination of the server process (On Windows it seems not yet fixed (very old but seems still the case: https://bugs.openjdk.org/browse/JDK-8056139) that in turn will not run its shutdown hooks: [https://github.com/wildfly-extras/wildfly-jar-maven-plugin/blob/main/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java#L1301](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/blob/main/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java#L1301))

If the test was not calling a shutdown of the server in // with the DevWatchGoal shutdown, I suspect that we shouldn't observe the issue.

If a failure occurs, calling process.destroy is the right thing to do. We want the process to end, in Dev Mode having the installation directory to be deleted is needed but is not that strict. We should add a WARN trace. I logged:

https://github.com/wildfly-extras/wildfly-jar-maven-plugin/issues/398

 

We have 4 processes:

In the Test process:

When the test is done.
First shutdown the server asynchronously (:shutdown)
Then write a file to have the mvn process to exit
Then wait 60 seconds for the mvn process to exit
If after 60secs it has not exited, fail the test ==> What we observe

In the mvn process:
The process has detected that it needs to exit (presence of the file)
It exists
Shutdown hook to shutdown the server is run

If an exception is thrown when calling server :shutdown (perhaps because of the shutdown, initiated by the test), process.destroy is called (https://github.com/wildfly-extras/wildfly-jar-maven-plugin/blob/main/plugin/src/main/java/org/wildfly/plugins/bootablejar/maven/goals/DevWatchBootableJarMojo.java#L1301)

On Windows process.destroy will make the process to exit without giving time to the shutdown hook to run.

Then it wait 60secs for the server to delete the installation (based on a marker file). ==> We observe that it waited and the server dir was not deleted

In the server process:
When shutdown is received, shutdown hook are run and cleanup of the server installation is fired in a new process (Only on windows due to file lock)

In the cleanup process:
Clean the file and exit
This one seems not started.